### PR TITLE
Add USE_ALLOC_MONITOR and USE_LATENCY_MONITOR as options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,8 +155,17 @@ endif ()
 
 #  Optional deugging/profiling tools to switch on.
 
-# add_definitions (-DNN_ALLOC_MONITOR)
-# add_definitions (-DNN_LATENCY_MONITOR=1000)
+option (USE_ALLOC_MONITOR
+    "Add memory allocation monitoring" OFF)
+option (USE_LATENCY_MONITOR
+    "Add latency monitoring" OFF)
+
+if (USE_ALLOC_MONITOR)
+    add_definitions(-DNN_ALLOC_MONITOR)
+endif ()
+if (USE_LATENCY_MONITOR)
+    add_definitions(-DNN_LATENCY_MONITOR=1000)
+endif ()
 
 #  Subdirectories to build.
 


### PR DESCRIPTION
This allows to build multiple versions of library from single source
without modifying source each time.

E.g:

```
mkdir build_lat_mon
cd build_lat_mon
cmake .. -DUSE_LATENCY_MONITOR=ON
```

You can also see all the options from menu:

```
ccmake ..
```
