### PR TITLE
Fix EPROTO conflict

### DIFF
--- a/src/nn.h
+++ b/src/nn.h
@@ -114,7 +114,7 @@ NN_EXPORT void nn_version (int *major, int *minor, int *patch);
 #define NN_EAFNOSUPPORT_DEFINED
 #endif
 #ifndef EPROTO
-#define EPROTO (NN_HAUSNUMERO + 10)
+#define EPROTO (NN_HAUSNUMERO + 11)
 #define NN_EPROTO_DEFINED
 #endif
 


### PR DESCRIPTION
If a platform is missing a POSIX errno that nanomsg requires, nanomsg will provide its own definition.  The definitions of EAFNOSUPPORT and EPROTO erroneously resolved to the same value.

This patch cranks EPROTO up to 11.

Released under the MIT license.
