### PR TITLE
IOV buffers lost when sendmsg() doesn't send all IOV buffers.

### DIFF
--- a/src/utils/aio_posix.inc
+++ b/src/utils/aio_posix.inc
@@ -897,12 +897,13 @@ static int nn_usock_recv_raw (struct nn_usock *self, void *buf, size_t *len)
         nbytes = recv (self->s, self->in.batch, NN_USOCK_BATCH_SIZE, 0);
 
     /*  Handle any possible errors. */
-    if (nn_slow (nbytes < 0)) {
+    if (nn_slow (nbytes <= 0)) {
 
         /*  Zero bytes received. */
         if (nn_fast (errno == EAGAIN || errno == EWOULDBLOCK))
             nbytes = 0;
         else {
+            if (nbytes == 0) return -ECONNRESET;
 
             /*  If the peer closes the connection, return ECONNRESET. */
             errno_assert (errno == ECONNRESET || errno == ENOTCONN ||


### PR DESCRIPTION
When sendmsg() stops sending on a IOV boundary, the other IOV buffers are lost.

Also when recv() returns 0 the connection is closed.
