### PR TITLE
Updated CMake build package script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,13 @@ endif ()
 # installation on the box.
 option (ZMQ_COMPAT "Build ZMQ compatibility library" OFF)
 
+#  Version.
+
+file (READ "${PROJECT_SOURCE_DIR}/src/nn.h" NN_H_DATA)
+string (REGEX REPLACE ".*#define NN_VERSION_MAJOR ([0-9]+).*" "\\1" NN_VERSION_MAJOR "${NN_H_DATA}")
+string (REGEX REPLACE ".*#define NN_VERSION_MINOR ([0-9]+).*" "\\1" NN_VERSION_MINOR "${NN_H_DATA}")
+string (REGEX REPLACE ".*#define NN_VERSION_PATCH ([0-9]+).*" "\\1" NN_VERSION_PATCH "${NN_H_DATA}")
+set (NN_VERSION_STR "${NN_VERSION_MAJOR}.${NN_VERSION_MINOR}.${NN_VERSION_PATCH}")
 
 #  Subdirectories to build.
 
@@ -192,7 +199,7 @@ add_subdirectory (tests)
 add_subdirectory (perf)
 add_subdirectory (doc)
 if (ZMQ_COMPAT)
-add_subdirectory (compat/zmq)
+    add_subdirectory (compat/zmq)
 endif ()
 
 #  Installation.
@@ -209,25 +216,26 @@ install (FILES src/fanout.h DESTINATION include/nanomsg)
 install (FILES src/survey.h DESTINATION include/nanomsg)
 install (FILES src/bus.h DESTINATION include/nanomsg)
 
-#  Packaging.
-
-file (READ "${PROJECT_SOURCE_DIR}/src/nn.h" NN_H_DATA)
-string (REGEX REPLACE ".*#define NN_VERSION_MAJOR ([0-9]+).*" "\\1" NN_VERSION_MAJOR "${NN_H_DATA}")
-string (REGEX REPLACE ".*#define NN_VERSION_MINOR ([0-9]+).*" "\\1" NN_VERSION_MINOR "${NN_H_DATA}")
-string (REGEX REPLACE ".*#define NN_VERSION_PATCH ([0-9]+).*" "\\1" NN_VERSION_PATCH "${NN_H_DATA}")
-
 # Source package.
 
 if (NOT WIN32)
-set (CPACK_SOURCE_GENERATOR ZIP)
+    set (CPACK_SOURCE_GENERATOR ZIP)
 else ()
-set (CPACK_SOURCE_GENERATOR TGZ)
+    set (CPACK_SOURCE_GENERATOR TGZ)
 endif ()
-set (CPACK_SOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${NN_VERSION_MAJOR}.${NN_VERSION_MINOR}.${NN_VERSION_PATCH}")
+set (CPACK_SOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${NN_VERSION_STR}")
 set (CPACK_SOURCE_IGNORE_FILES "/build/;/.git/;.gitignore;README.md;${CPACK_SOURCE_IGNORE_FILES}")
 add_custom_target (dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
 
 #  Create the packages.
+
+set(CPACK_PACKAGE_NAME "${CMAKE_PROJECT_NAME}")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
+    "nanomsg library is a high-performance implementation of several \"scalability protocols\". Scalability protocol's job is to define how multiple applications communicate to form a single distributed application")
+set(CPACK_PACKAGE_VERSION "${NN_VERSION_STR}")
+set(CPACK_PACKAGE_VERSION_MAJOR "${NN_VERSION_MAJOR}")
+set(CPACK_PACKAGE_VERSION_MINOR "${NN_VERSION_MINOR}")
+set(CPACK_PACKAGE_VERSION_PATCH "${NN_VERSION_PATCH}")
 
 include (CPack)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-add_library (nanomsg SHARED
+set (NN_SOURCES
     nn.h
     transport.h
     protocol.h
@@ -75,7 +75,7 @@ add_library (nanomsg SHARED
     utils/dist.c
     utils/efd.h
     utils/efd.c
-    utils/err.h 
+    utils/err.h
     utils/err.c
     utils/excl.h
     utils/excl.c
@@ -188,7 +188,10 @@ add_library (nanomsg SHARED
 
     transports/tcp/tcp.h
     transports/tcp/tcp.c
-    )
+)
+
+add_library (nanomsg SHARED ${NN_SOURCES})
+set_target_properties (nanomsg PROPERTIES VERSION "${NN_VERSION_STR}")
 
 add_definitions (-DNN_EXPORTS)
 

--- a/src/nn.h
+++ b/src/nn.h
@@ -189,9 +189,9 @@ NN_EXPORT struct nn_cmsghdr *nn_cmsg_nexthdr (const struct nn_msghdr *mhdr,
 
 /*  Helper macro. Not to be used directly.                                    */
 #define NN_CMSG_ALIGN(len) \
-    (((len) + sizeof (size_t) - 1) & (size_t) ~(sizeof (size_t) - 1)) 
+    (((len) + sizeof (size_t) - 1) & (size_t) ~(sizeof (size_t) - 1))
 
-/* Extensions to POSIX defined by RFC3542.                                    */                                    
+/* Extensions to POSIX defined by RFC3542.                                    */
 
 #define NN_CMSG_SPACE(len) \
     (CMSG_ALIGN (len) + CMSG_ALIGN (sizeof (struct nn_cmsghdr)))
@@ -230,7 +230,7 @@ NN_EXPORT struct nn_cmsghdr *nn_cmsg_nexthdr (const struct nn_msghdr *mhdr,
 NN_EXPORT int nn_socket (int domain, int protocol);
 NN_EXPORT int nn_close (int s);
 NN_EXPORT int nn_setsockopt (int s, int level, int option, const void *optval,
-    size_t optvallen); 
+    size_t optvallen);
 NN_EXPORT int nn_getsockopt (int s, int level, int option, void *optval,
     size_t *optvallen);
 NN_EXPORT int nn_bind (int s, const char *addr);


### PR DESCRIPTION
The patch fix "make package" output file name. Also it's created dll with version suffix, i.e. libnanomsg.so.0.0.0 (libnanomsg.so link also included).

MIT License
