### PR TITLE
Add pthread to CMake check for semaphore support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if (NN_HAVE_GETADDRINFO_A)
     add_definitions (-DNN_HAVE_GETADDRINFO_A)
 endif ()
 
-list (APPEND CMAKE_REQUIRED_LIBRARIES rt)
+list (APPEND CMAKE_REQUIRED_LIBRARIES rt pthread)
 check_symbol_exists (sem_wait semaphore.h NN_HAVE_SEMAPHORE)
 list (REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES rt)
 if (NN_HAVE_SEMAPHORE)


### PR DESCRIPTION
Fixes issue #53

Some systems have sem_wait in librt, some in libpthread.
This add pthread to the CMake check for semaphore support.

Released under the MIT license.
