### PR TITLE
added pkgconfig for UNIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,10 @@ string (REGEX REPLACE ".*#define NN_VERSION_MINOR ([0-9]+).*" "\\1" NN_VERSION_M
 string (REGEX REPLACE ".*#define NN_VERSION_PATCH ([0-9]+).*" "\\1" NN_VERSION_PATCH "${NN_H_DATA}")
 set (NN_VERSION_STR "${NN_VERSION_MAJOR}.${NN_VERSION_MINOR}.${NN_VERSION_PATCH}")
 
+#  Description
+
+set (NN_DESCRIPTION "nanomsg library is a high-performance implementation of several \"scalability protocols\". Scalability protocol's job is to define how multiple applications communicate to form a single distributed application")
+
 #  Subdirectories to build.
 
 add_subdirectory (src)
@@ -262,8 +266,7 @@ add_custom_target (dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
 #  Create the packages.
 
 set (CPACK_PACKAGE_NAME "${CMAKE_PROJECT_NAME}")
-set (CPACK_PACKAGE_DESCRIPTION_SUMMARY
-    "nanomsg library is a high-performance implementation of several \"scalability protocols\". Scalability protocol's job is to define how multiple applications communicate to form a single distributed application")
+set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "${NN_DESCRIPTION}")
 set (CPACK_PACKAGE_VERSION "${NN_VERSION_STR}")
 set (CPACK_PACKAGE_VERSION_MAJOR "${NN_VERSION_MAJOR}")
 set (CPACK_PACKAGE_VERSION_MINOR "${NN_VERSION_MINOR}")

--- a/README
+++ b/README
@@ -16,7 +16,7 @@ Build it
 3.  cd nanomsg
 4.  mkdir build
 5.  cd build
-6.  cmake ..
+6.  cmake .. # or cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
 7.  make
 8.  make check
 9.  sudo make install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -224,3 +224,9 @@ target_link_libraries (nanomsg ${CMAKE_THREAD_LIBS_INIT})
 
 install (TARGETS nanomsg DESTINATION lib)
 
+# pkg-config file
+if (UNIX)
+    configure_file (pkgconfig.in ${CMAKE_PROJECT_NAME}.pc @ONLY)
+    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}.pc DESTINATION lib/pkgconfig)
+endif ()
+

--- a/src/pkgconfig.in
+++ b/src/pkgconfig.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: @CMAKE_PROJECT_NAME@
+Description: @NN_DESCRIPTION@
+URL: http://nanomsg.org/
+Version: @NN_VERSION_STR@
+Requires:
+Libs: -L${libdir} -l@CMAKE_PROJECT_NAME@
+Cflags: -I${includedir}


### PR DESCRIPTION
1. Added nanomsg.pc file generation for pkg-config (for UNIX only)
2. Added information to README to choose different installation directory

MIT License
