### PR TITLE
Include NN_MSG in nn_symbol

### DIFF
--- a/src/core/symbol.c
+++ b/src/core/symbol.c
@@ -87,6 +87,7 @@ static const struct sym_value_name sym_value_names [] = {
     {NN_TCP_NODELAY, "NN_TCP_NODELAY"},
 
     {NN_DONTWAIT, "NN_DONTWAIT"},
+    {NN_MSG, "NN_MSG"},
 
     {EADDRINUSE, "EADDRINUSE"},
     {EADDRNOTAVAIL, "EADDRNOTAVAIL"},


### PR DESCRIPTION
This patch is submitted under MIT/X11 license.

Signed-off-by: Florian Ragwitz rafl@debian.org
