### PR TITLE
Be explicit about NN_IPV4ONLY option type

### DIFF
--- a/doc/nn_getsockopt.txt
+++ b/doc/nn_getsockopt.txt
@@ -80,7 +80,7 @@ _<nanomsg/nn.h>_ header defines generic socket-level options
     priority is 1, lowest priority is 16. Default value is 8.
 *NN_IPV4ONLY*::
     If set to 1, only IPv4 addresses are used. If set to 0, both IPv4 and IPv6
-    addresses are used. Default value is 1.
+    addresses are used. The type of the option is int. Default value is 1.
 *NN_SNDFD*::
     Retrieves a file descriptor that is readable when a message can be sent
     to the socket. The descriptor should be used only for polling and never


### PR DESCRIPTION
I'm okay with licensing this under the MIT license.
