### PR TITLE
Fix error in header guard in bus.h

### DIFF
--- a/src/protocols/bus/bus.h
+++ b/src/protocols/bus/bus.h
@@ -21,7 +21,7 @@
 */
 
 #ifndef NN_BUS_INCLUDED
-#define NN_PBUS_INCLUDED
+#define NN_BUS_INCLUDED
 
 #include "../../protocol.h"
 


### PR DESCRIPTION
Spotted by clang

The patch is submitted under MIT license
