### PR TITLE
Refactored FSM shutdown code to separate state machine callback

### DIFF
--- a/src/aio/fsm.h
+++ b/src/aio/fsm.h
@@ -65,6 +65,7 @@ struct nn_fsm_owner {
 
 struct nn_fsm {
     nn_fsm_fn fn;
+    nn_fsm_fn shutdown_fn;
     int state;
     int src;
     void *srcptr;
@@ -73,9 +74,11 @@ struct nn_fsm {
     struct nn_fsm_event stopped;
 };
 
-void nn_fsm_init_root (struct nn_fsm *self, nn_fsm_fn fn, struct nn_ctx *ctx);
-void nn_fsm_init (struct nn_fsm *self, nn_fsm_fn fn, int src, void *srcptr,
-    struct nn_fsm *owner);
+void nn_fsm_init_root (struct nn_fsm *self, nn_fsm_fn fn,
+    nn_fsm_fn shutdown_fn, struct nn_ctx *ctx);
+void nn_fsm_init (struct nn_fsm *self, nn_fsm_fn fn,
+    nn_fsm_fn shutdown_fn,
+    int src, void *srcptr, struct nn_fsm *owner);
 void nn_fsm_term (struct nn_fsm *self);
 
 int nn_fsm_isidle (struct nn_fsm *self);
@@ -96,6 +99,7 @@ void nn_fsm_action (struct nn_fsm *self, int type);
 /*  Send event from the state machine to its owner. */
 void nn_fsm_raise (struct nn_fsm *self, struct nn_fsm_event *event, int type);
 
+
 /*  Send event to the specified state machine. It's caller's responsibility
     to ensure that the destination state machine will still exist when the
     event is delivered.
@@ -103,6 +107,11 @@ void nn_fsm_raise (struct nn_fsm *self, struct nn_fsm_event *event, int type);
     efficient manner. Do not use it outside of inproc transport! */
 void nn_fsm_raiseto (struct nn_fsm *self, struct nn_fsm *dst,
     struct nn_fsm_event *event, int src, int type, void *srcptr);
+
+/*  This function is very lowlevel action feeding
+    Used in worker threads and timers, shouldn't be used by others
+    use nn_fsm_action/nn_fsm_raise/nn_fsm_raiseto instread*/
+void nn_fsm_feed (struct nn_fsm *self, int src, int type, void *srcptr);
 
 #endif
 

--- a/src/aio/usock_posix.inc
+++ b/src/aio/usock_posix.inc
@@ -68,11 +68,14 @@ static int nn_usock_recv_raw (struct nn_usock *self, void *buf, size_t *len);
 static int nn_usock_geterr (struct nn_usock *self);
 static void nn_usock_handler (struct nn_fsm *self, int src, int type,
     void *srcptr);
+static void nn_usock_shutdown (struct nn_fsm *self, int src, int type,
+    void *srcptr);
 
 void nn_usock_init (struct nn_usock *self, int src, struct nn_fsm *owner)
 {
     /*  Initalise the state machine. */
-    nn_fsm_init (&self->fsm, nn_usock_handler, src, self, owner);
+    nn_fsm_init (&self->fsm, nn_usock_handler, nn_usock_shutdown,
+        src, self, owner);
     self->state = NN_USOCK_STATE_IDLE;
 
     /*  Choose a worker thread to handle this socket. */
@@ -436,15 +439,8 @@ void nn_usock_recv (struct nn_usock *self, void *buf, size_t len)
     nn_worker_execute (self->worker, &self->task_recv);
 }
 
-static void nn_usock_handler (struct nn_fsm *self, int src, int type,
-    void *srcptr)
+static int nn_internal_tasks (struct nn_usock *usock, int src, int type)
 {
-    int rc;
-    struct nn_usock *usock;
-    int s;
-    size_t sz;
-
-    usock = nn_cont (self, struct nn_usock, fsm);
 
 /******************************************************************************/
 /*  Internal tasks sent from the user thread to the worker thread.            */
@@ -453,30 +449,41 @@ static void nn_usock_handler (struct nn_fsm *self, int src, int type,
     case NN_USOCK_SRC_TASK_SEND:
         nn_assert (type == NN_WORKER_TASK_EXECUTE);
         nn_worker_set_out (usock->worker, &usock->wfd);
-        return;
+        return 1;
     case NN_USOCK_SRC_TASK_RECV:
         nn_assert (type == NN_WORKER_TASK_EXECUTE);
         nn_worker_set_in (usock->worker, &usock->wfd);
-        return;
+        return 1;
     case NN_USOCK_SRC_TASK_CONNECTED:
         nn_assert (type == NN_WORKER_TASK_EXECUTE);
         nn_worker_add_fd (usock->worker, usock->s, &usock->wfd);
-        return;
+        return 1;
     case NN_USOCK_SRC_TASK_CONNECTING:
         nn_assert (type == NN_WORKER_TASK_EXECUTE);
         nn_worker_add_fd (usock->worker, usock->s, &usock->wfd);
         nn_worker_set_out (usock->worker, &usock->wfd);
-        return;
+        return 1;
     case NN_USOCK_SRC_TASK_ACCEPT:
         nn_assert (type == NN_WORKER_TASK_EXECUTE);
         nn_worker_add_fd (usock->worker, usock->s, &usock->wfd);
         nn_worker_set_in (usock->worker, &usock->wfd);
-        return;
+        return 1;
     }
 
-/******************************************************************************/
-/*  STOP procedure.                                                           */
-/******************************************************************************/
+    return 0;
+}
+
+static void nn_usock_shutdown (struct nn_fsm *self, int src, int type,
+    void *srcptr)
+{
+    int rc;
+    struct nn_usock *usock;
+
+    usock = nn_cont (self, struct nn_usock, fsm);
+
+    if(nn_internal_tasks(usock, src, type))
+        return;
+
     if (nn_slow (src == NN_FSM_ACTION && type == NN_FSM_STOP)) {
 
         /*  Socket in ACCEPTING or CANCELLING state cannot be closed.
@@ -527,6 +534,22 @@ finish2:
 finish3:
         return;
     }
+
+    nn_fsm_bad_state(usock->state, src, type);
+}
+
+static void nn_usock_handler (struct nn_fsm *self, int src, int type,
+    void *srcptr)
+{
+    int rc;
+    struct nn_usock *usock;
+    int s;
+    size_t sz;
+
+    usock = nn_cont (self, struct nn_usock, fsm);
+
+    if(nn_internal_tasks(usock, src, type))
+        return;
 
     switch (usock->state) {
 

--- a/src/aio/usock_win.inc
+++ b/src/aio/usock_win.inc
@@ -59,11 +59,14 @@
 /*  Private functions. */
 static void nn_usock_handler (struct nn_fsm *self, int src, int type,
     void *srcptr);
+static void nn_usock_shutdown (struct nn_fsm *self, int src, int type,
+    void *srcptr);
 static int nn_usock_cancel_io (struct nn_usock *self);
 
 void nn_usock_init (struct nn_usock *self, int src, struct nn_fsm *owner)
 {
-    nn_fsm_init (&self->fsm, nn_usock_handler, src, self, owner);
+    nn_fsm_init (&self->fsm, nn_usock_handler, nn_usock_shutdown,
+        src, self, owner);
     self->state = NN_USOCK_STATE_IDLE;
     self->s = INVALID_SOCKET;
     nn_worker_op_init (&self->in, NN_USOCK_SRC_IN, &self->fsm);
@@ -295,7 +298,7 @@ void nn_usock_connect (struct nn_usock *self, const struct sockaddr *addr,
     memset (&self->out.olpd, 0, sizeof (self->out.olpd));
     brc = pconnectex (self->s, (struct sockaddr*) addr, addrlen,
         NULL, 0, NULL, &self->out.olpd);
-    
+
     /*  Immediate success. */
     if (nn_fast (brc == TRUE)) {
         nn_fsm_action (&self->fsm, NN_USOCK_ACTION_DONE);
@@ -393,11 +396,6 @@ static void nn_usock_handler (struct nn_fsm *self, int src, int type,
     int rc;
     struct nn_usock *usock;
 
-    usock = nn_cont (self, struct nn_usock, fsm);
-
-/******************************************************************************/
-/*  STOP procedure.                                                           */
-/******************************************************************************/
     if (nn_slow (src == NN_FSM_ACTION && type == NN_FSM_STOP)) {
 
         /*  Socket in ACCEPTING state cannot be closed.
@@ -436,7 +434,7 @@ static void nn_usock_handler (struct nn_fsm *self, int src, int type,
             goto finish1;
         usock->state = NN_USOCK_STATE_STOPPING;
         return;
-    } 
+    }
     if (nn_slow (usock->state == NN_USOCK_STATE_STOPPING_ACCEPT)) {
         nn_assert (src == NN_FSM_ACTION && type == NN_USOCK_ACTION_DONE);
         goto finish1;
@@ -454,6 +452,17 @@ finish2:
 finish3:
         return;
     }
+
+    nn_fsm_bad_state(usock->state, src, type);
+}
+
+static void nn_usock_handler (struct nn_fsm *self, int src, int type,
+    void *srcptr)
+{
+    int rc;
+    struct nn_usock *usock;
+
+    usock = nn_cont (self, struct nn_usock, fsm);
 
     switch (usock->state) {
 

--- a/src/aio/worker_posix.inc
+++ b/src/aio/worker_posix.inc
@@ -176,7 +176,7 @@ static void nn_worker_routine (void *arg)
             errnum_assert (rc == 0, -rc);
             timer = nn_cont (thndl, struct nn_worker_timer, hndl);
             nn_ctx_enter (timer->owner->ctx);
-            timer->owner->fn (timer->owner, -1, NN_WORKER_TIMER_TIMEOUT, timer);
+            nn_fsm_feed (timer->owner, -1, NN_WORKER_TIMER_TIMEOUT, timer);
             nn_ctx_leave (timer->owner->ctx);
         }
 
@@ -219,7 +219,7 @@ static void nn_worker_routine (void *arg)
                         arrived in the worker thread. */
                     task = nn_cont (item, struct nn_worker_task, item);
                     nn_ctx_enter (task->owner->ctx);
-                    task->owner->fn (task->owner, task->src,
+                    nn_fsm_feed (task->owner, task->src,
                         NN_WORKER_TASK_EXECUTE, task);
                     nn_ctx_leave (task->owner->ctx);
                 }
@@ -230,7 +230,7 @@ static void nn_worker_routine (void *arg)
             /*  It's a true I/O event. Invoke the handler. */
             fd = nn_cont (phndl, struct nn_worker_fd, hndl);
             nn_ctx_enter (fd->owner->ctx);
-            fd->owner->fn (fd->owner, fd->src, pevent, fd);
+            nn_fsm_feed (fd->owner, fd->src, pevent, fd);
             nn_ctx_leave (fd->owner->ctx);
         }
     }

--- a/src/aio/worker_win.inc
+++ b/src/aio/worker_win.inc
@@ -155,7 +155,7 @@ static void nn_worker_routine (void *arg)
             errnum_assert (rc == 0, -rc);
             timer = nn_cont (thndl, struct nn_worker_timer, hndl);
             nn_ctx_enter (timer->owner->ctx);
-            timer->owner->fn (timer->owner, -1, NN_WORKER_TIMER_TIMEOUT, timer);
+            nn_fsm_feed (timer->owner, -1, NN_WORKER_TIMER_TIMEOUT, timer);
             nn_ctx_leave (timer->owner->ctx);
         }
 
@@ -200,7 +200,7 @@ static void nn_worker_routine (void *arg)
                       entries [i].dwNumberOfBytesTransferred == 0)
                     rc = NN_WORKER_OP_ERROR;
                 op->state = NN_WORKER_OP_STATE_IDLE;
-                op->owner->fn (op->owner, op->src, rc, op);
+                nn_fsm_feed (op->owner, op->src, rc, op);
                 nn_ctx_leave (op->owner->ctx);
 
                 continue;
@@ -214,7 +214,7 @@ static void nn_worker_routine (void *arg)
             /*  Process tasks. */
             task = (struct nn_worker_task*) entries [i].lpCompletionKey;
             nn_ctx_enter (task->owner->ctx);
-            task->owner->fn (task->owner, task->src,
+            nn_fsm_feed (task->owner, task->src,
                 NN_WORKER_TASK_EXECUTE, task);
             nn_ctx_leave (task->owner->ctx);
         }

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -50,7 +50,7 @@ void nn_pipebase_init (struct nn_pipebase *self,
 {
     nn_assert (epbase->ep->sock);
 
-    nn_fsm_init (&self->fsm, NULL, 0, self, &epbase->ep->sock->fsm);
+    nn_fsm_init (&self->fsm, NULL, NULL, 0, self, &epbase->ep->sock->fsm);
     self->vfptr = vfptr;
     self->state = NN_PIPEBASE_STATE_IDLE;
     self->instate = NN_PIPEBASE_INSTATE_DEACTIVATED;
@@ -62,7 +62,7 @@ void nn_pipebase_init (struct nn_pipebase *self,
 
 void nn_pipebase_term (struct nn_pipebase *self)
 {
-    nn_assert (self->state == NN_PIPEBASE_STATE_IDLE); 
+    nn_assert (self->state == NN_PIPEBASE_STATE_IDLE);
 
     nn_fsm_event_term (&self->out);
     nn_fsm_event_term (&self->in);

--- a/src/transports/utils/dns_getaddrinfo.inc
+++ b/src/transports/utils/dns_getaddrinfo.inc
@@ -39,10 +39,13 @@
 /*  Private functions. */
 static void nn_dns_handler (struct nn_fsm *self, int src, int type,
     void *srcptr);
+static void nn_dns_shutdown (struct nn_fsm *self, int src, int type,
+    void *srcptr);
 
 void nn_dns_init (struct nn_dns *self, int src, struct nn_fsm *owner)
 {
-    nn_fsm_init (&self->fsm, nn_dns_handler, src, self, owner);
+    nn_fsm_init (&self->fsm, nn_dns_handler, nn_dns_shutdown,
+        src, self, owner);
     self->state = NN_DNS_STATE_IDLE;
     nn_fsm_event_init (&self->done);
 }
@@ -120,21 +123,27 @@ void nn_dns_stop (struct nn_dns *self)
     nn_fsm_stop (&self->fsm);
 }
 
+static void nn_dns_shutdown (struct nn_fsm *self, int src, int type,
+    void *srcptr)
+{
+    struct nn_dns *dns;
+
+    dns = nn_cont (self, struct nn_dns, fsm);
+    if (nn_slow (src == NN_FSM_ACTION && type == NN_FSM_STOP)) {
+        nn_fsm_stopped (&dns->fsm, NN_DNS_STOPPED);
+        dns->state = NN_DNS_STATE_IDLE;
+        return;
+    }
+
+    nn_fsm_bad_state(dns->state, src, type);
+}
+
 static void nn_dns_handler (struct nn_fsm *self, int src, int type,
     void *srcptr)
 {
     struct nn_dns *dns;
 
     dns = nn_cont (self, struct nn_dns, fsm);
-
-/******************************************************************************/
-/*  STOP procedure.                                                           */
-/******************************************************************************/
-    if (nn_slow (src == NN_FSM_ACTION && type == NN_FSM_STOP)) {
-        nn_fsm_stopped (&dns->fsm, NN_DNS_STOPPED);
-        dns->state = NN_DNS_STATE_IDLE;
-        return;
-    }
 
     switch (dns->state) {
 /******************************************************************************/

--- a/src/transports/utils/dns_getaddrinfo_a.inc
+++ b/src/transports/utils/dns_getaddrinfo_a.inc
@@ -41,10 +41,12 @@
 static void nn_dns_notify (union sigval);
 static void nn_dns_handler (struct nn_fsm *self, int src, int type,
     void *srcptr);
+static void nn_dns_shutdown (struct nn_fsm *self, int src, int type,
+    void *srcptr);
 
 void nn_dns_init (struct nn_dns *self, int src, struct nn_fsm *owner)
 {
-    nn_fsm_init (&self->fsm, nn_dns_handler, src, self, owner);
+    nn_fsm_init (&self->fsm, nn_dns_handler, nn_dns_shutdown, src, self, owner);
     self->state = NN_DNS_STATE_IDLE;
     nn_fsm_event_init (&self->done);
 }
@@ -153,7 +155,7 @@ static void nn_dns_notify (union sigval sval)
     nn_ctx_leave (self->fsm.ctx);
 }
 
-static void nn_dns_handler (struct nn_fsm *self, int src, int type,
+static void nn_dns_shutdown (struct nn_fsm *self, int src, int type,
     void *srcptr)
 {
     int rc;
@@ -161,9 +163,6 @@ static void nn_dns_handler (struct nn_fsm *self, int src, int type,
 
     dns = nn_cont (self, struct nn_dns, fsm);
 
-/******************************************************************************/
-/*  STOP procedure.                                                           */
-/******************************************************************************/
     if (nn_slow (src == NN_FSM_ACTION && type == NN_FSM_STOP)) {
         if (dns->state == NN_DNS_STATE_RESOLVING) {
             rc = gai_cancel (&dns->gcb);
@@ -191,6 +190,17 @@ static void nn_dns_handler (struct nn_fsm *self, int src, int type,
         }
         return;
     }
+
+    nn_fsm_bad_state (dns->state, src, type);
+}
+
+static void nn_dns_handler (struct nn_fsm *self, int src, int type,
+    void *srcptr)
+{
+    int rc;
+    struct nn_dns *dns;
+
+    dns = nn_cont (self, struct nn_dns, fsm);
 
     switch (dns->state) {
 /******************************************************************************/


### PR DESCRIPTION
All tests work on Linux. Doesn't tested on Windows. But rework is rather mechanical so should be easy to fix if there are typos in Windows code.

The patch is submitted under MIT License
