### PR TITLE
Fix race condition in surveyor

### DIFF
--- a/src/protocols/survey/surveyor.c
+++ b/src/protocols/survey/surveyor.c
@@ -450,6 +450,15 @@ static void nn_surveyor_handler (struct nn_fsm *self, int src, int type,
     case NN_SURVEYOR_STATE_STOPPING_TIMER:
         switch (src) {
 
+        case NN_FSM_ACTION:
+            switch (type) {
+            case NN_SURVEYOR_ACTION_CANCEL:
+                surveyor->state = NN_SURVEYOR_STATE_CANCELLING;
+                return;
+            default:
+                nn_fsm_bad_action (surveyor->state, src, type);
+            }
+
         case NN_SURVEYOR_SRC_DEADLINE_TIMER:
             switch (type) {
             case NN_TIMER_STOPPED:


### PR DESCRIPTION
I can't make a reliable unit test for this. But it's reproduces with `nanocat` with the following.

Run respondent:

```
nanocat --respondent --bind tcp://127.0.0.1:1234 --data=world -A
```

Run surveyor, with interval 1 second (it seems magical interval at least for my system):

```
nanocat --surveyor --connect tcp://127.0.0.1:1234 --data=hello -A  --interval 1
```

Then after about 1 to 10 roundtrips it crashes with the following error:

```
Unexpected source: state=5 source=-2 action=2 (../src/protocols/survey/surveyor.c:463)
```

The patch is submitted under MIT License
