### PR TITLE
Fixes a build issue on some platforms, due to missing stdint.h

### DIFF
--- a/src/aio/poller_epoll.h
+++ b/src/aio/poller_epoll.h
@@ -21,6 +21,7 @@
 */
 
 #include <sys/epoll.h>
+#include <stdint.h>
 
 #define NN_POLLER_HAVE_ASYNC_ADD 1
 


### PR DESCRIPTION
Fixes following compile error on my target platform:

```
In file included from src/aio/poller.h:35:0,
             from src/aio/poller.c:23:
src/aio/poller_epoll.h:31:5: error: unknown type name 'uint32_t'
make: *** [src/aio/poller.lo] Error 1
```

Shouldn't break anything else. MIT LICENSE naturally.
