### PR TITLE
Fixing building documentation when build tree is other than the source t...

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -345,7 +345,8 @@ if DOC
 #  Build instructions.
 
 .txt.xml:
-	$(AM_V_GEN)$(ASCIIDOC) -d manpage -b docbook -f doc/asciidoc.conf \
+	$(AM_V_GEN)$(ASCIIDOC) -d manpage -b docbook \
+        -f $(abs_srcdir)/doc/asciidoc.conf \
         -aversion=@NN_PACKAGE_VERSION@ -o $@ $<
 
 SUFFIXES = .1 .3 .7 .1.html .3.html .7.html
@@ -358,17 +359,20 @@ SUFFIXES = .1 .3 .7 .1.html .3.html .7.html
 
 .txt.1.html:
 	$(AM_V_GEN)$(ASCIIDOC) -d manpage -b xhtml11 \
-        -a stylesheet=$(abs_srcdir)/doc/htmldoc.css -f doc/asciidoc.conf \
+        -a stylesheet=$(abs_srcdir)/doc/htmldoc.css \
+        -f $(abs_srcdir)/doc/asciidoc.conf \
         -aversion=@NN_PACKAGE_VERSION@ -o $@ $<
 
 .txt.3.html:
 	$(AM_V_GEN)$(ASCIIDOC) -d manpage -b xhtml11 \
-        -a stylesheet=$(abs_srcdir)/doc/htmldoc.css -f doc/asciidoc.conf \
+        -a stylesheet=$(abs_srcdir)/doc/htmldoc.css \
+        -f $(abs_srcdir)/doc/asciidoc.conf \
         -aversion=@NN_PACKAGE_VERSION@ -o $@ $<
 
 .txt.7.html:
 	$(AM_V_GEN)$(ASCIIDOC) -d manpage -b xhtml11 \
-        -a stylesheet=$(abs_srcdir)/doc/htmldoc.css -f doc/asciidoc.conf \
+        -a stylesheet=$(abs_srcdir)/doc/htmldoc.css \
+        -f $(abs_srcdir)/doc/asciidoc.conf \
         -aversion=@NN_PACKAGE_VERSION@ -o $@ $<
 
 #  Cause man pages to be generated and installed.

--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,10 @@ AS_IF([test x"$enable_doc" = "xyes"], [
     AS_IF([test x"$XMLTO" = "x"], [
         AC_MSG_ERROR([Please install xmlto to build the documentation])
     ])
+    AS_IF([test ! -d "doc"], [
+        AC_PROG_MKDIR_P
+        AS_MKDIR_P("doc")
+    ])
 ])
 AM_CONDITIONAL([DOC], [test x"$ASCIIDOC" != "x" -a x"$XMLTO" != "x" ])
 


### PR DESCRIPTION
Hi there Martin, 

I was trying to build nanomsg in other tree than the source tree and the building process brakes when one tries to enable the generation of documentation ( --enable-doc ) and it happens basically because of 2 reasons if I understood correctly: 
1. The asciidoc.conf file is not found
2. The doc directory is missing, which is needed to hold the xml files that asciidoc generates and without those xml files the process of building the docs cant continue obviously. 

This pull request addresses both points. 

I must say I am not an autotools expert but this is the most reasonable way I found to fix it after reading some sections of the automake manual... maybe someone with a better insight has a better solution. 

Best, 
