### PR TITLE
Separate structure for per-endpoint options

### DIFF
--- a/src/core/ep.c
+++ b/src/core/ep.c
@@ -57,6 +57,7 @@ int nn_ep_init (struct nn_ep *self, int src, struct nn_sock *sock, int eid,
     self->sock = sock;
     self->eid = eid;
     nn_list_item_init (&self->item);
+    memcpy (&self->options, &sock->ep_template, sizeof(struct nn_ep_options));
 
     /*  Store the textual form of the address. */
     nn_assert (strlen (addr) <= NN_SOCKADDR_MAX);

--- a/src/core/ep.h
+++ b/src/core/ep.h
@@ -37,6 +37,7 @@ struct nn_ep {
     int state;
     struct nn_epbase *epbase;
     struct nn_sock *sock;
+    struct nn_ep_options options;
     int eid;
     struct nn_list_item item;
     char addr [NN_SOCKADDR_MAX + 1];

--- a/src/core/sock.c
+++ b/src/core/sock.c
@@ -124,8 +124,8 @@ int nn_sock_init (struct nn_sock *self, struct nn_socktype *socktype)
     self->rcvtimeo = -1;
     self->reconnect_ivl = 100;
     self->reconnect_ivl_max = 0;
-    self->sndprio = 8;
-    self->ipv4only = 1;
+    self->ep_template.sndprio = 8;
+    self->ep_template.ipv4only = 1;
 
     /*  The transport-specific options are not initialised immediately,
         rather, they are allocated later on when needed. */
@@ -298,12 +298,12 @@ static int nn_sock_setopt_inner (struct nn_sock *self, int level,
         case NN_SNDPRIO:
             if (nn_slow (val < 1 || val > 16))
                 return -EINVAL;
-            dst = &self->sndprio;
+            dst = &self->ep_template.sndprio;
             break;
         case NN_IPV4ONLY:
             if (nn_slow (val != 0 && val != 1))
                 return -EINVAL;
-            dst = &self->ipv4only;
+            dst = &self->ep_template.ipv4only;
             break;
         default:
             return -ENOPROTOOPT;
@@ -371,10 +371,10 @@ int nn_sock_getopt_inner (struct nn_sock *self, int level,
             intval = self->reconnect_ivl_max;
             break;
         case NN_SNDPRIO:
-            intval = self->sndprio;
+            intval = self->ep_template.sndprio;
             break;
         case NN_IPV4ONLY:
-            intval = self->ipv4only;
+            intval = self->ep_template.ipv4only;
             break;
         case NN_SNDFD:
             if (self->socktype->flags & NN_SOCKTYPE_FLAG_NOSEND)

--- a/src/core/sock.h
+++ b/src/core/sock.h
@@ -79,8 +79,9 @@ struct nn_sock
     int rcvtimeo;
     int reconnect_ivl;
     int reconnect_ivl_max;
-    int sndprio;
-    int ipv4only;
+
+    /*  Endpoint-specific options.  */
+    struct nn_ep_options ep_template;
 
     /*  Transport-specific socket options. */
     struct nn_optset *optsets [NN_MAX_TRANSPORT];
@@ -121,7 +122,7 @@ int nn_sock_recv (struct nn_sock *self, struct nn_msg *msg, int flags);
 
 /*  Set a socket option. */
 int nn_sock_setopt (struct nn_sock *self, int level, int option,
-    const void *optval, size_t optvallen); 
+    const void *optval, size_t optvallen);
 
 /*  Retrieve a socket option. This function is to be called from the API. */
 int nn_sock_getopt (struct nn_sock *self, int level, int option,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -69,6 +69,11 @@ int nn_pipe_send (struct nn_pipe *self, struct nn_msg *msg);
     the call. It will be initialised when the call succeeds. */
 int nn_pipe_recv (struct nn_pipe *self, struct nn_msg *msg);
 
+/*  Get option for pipe. Mostly useful for endpoint-specific options  */
+void nn_pipe_getopt (struct nn_pipe *self, int level, int option,
+    void *optval, size_t *optvallen);
+
+
 /******************************************************************************/
 /*  Base class for all socket types.                                          */
 /******************************************************************************/

--- a/src/protocols/pipeline/xpush.c
+++ b/src/protocols/pipeline/xpush.c
@@ -107,9 +107,9 @@ static int nn_xpush_add (struct nn_sockbase *self, struct nn_pipe *pipe)
     xpush = nn_cont (self, struct nn_xpush, sockbase);
 
     sz = sizeof (sndprio);
-    rc = nn_sockbase_getopt (&xpush->sockbase, NN_SNDPRIO, &sndprio, &sz);
-    errnum_assert (rc == 0, -rc);
+    nn_pipe_getopt (pipe, NN_SOL_SOCKET, NN_SNDPRIO, &sndprio, &sz);
     nn_assert (sz == sizeof (sndprio));
+    nn_assert (sndprio >= 1 && sndprio <= 16);
 
     data = nn_alloc (sizeof (struct nn_xpush_data), "pipe data (push)");
     alloc_assert (data);

--- a/src/protocols/reqrep/xreq.c
+++ b/src/protocols/reqrep/xreq.c
@@ -89,9 +89,9 @@ int nn_xreq_add (struct nn_sockbase *self, struct nn_pipe *pipe)
     xreq = nn_cont (self, struct nn_xreq, sockbase);
 
     sz = sizeof (sndprio);
-    rc = nn_sockbase_getopt (&xreq->sockbase, NN_SNDPRIO, &sndprio, &sz);
-    errnum_assert (rc == 0, -rc);
+    nn_pipe_getopt (pipe, NN_SOL_SOCKET, NN_SNDPRIO, &sndprio, &sz);
     nn_assert (sz == sizeof (sndprio));
+    nn_assert (sndprio >= 1 && sndprio <= 16);
 
     data = nn_alloc (sizeof (struct nn_xreq_data), "pipe data (req)");
     alloc_assert (data);

--- a/src/transport.h
+++ b/src/transport.h
@@ -31,6 +31,7 @@
 #include "utils/list.h"
 #include "utils/msg.h"
 #include "utils/int.h"
+#include "utils/int.h"
 
 #include <stddef.h>
 
@@ -142,6 +143,13 @@ struct nn_pipebase_vfptr {
     int (*recv) (struct nn_pipebase *self, struct nn_msg *msg);
 };
 
+/*  Endpoint specific options. Same restrictions as for nn_pipebase apply  */
+struct nn_ep_options
+{
+    int sndprio;
+    int ipv4only;
+};
+
 /*  The member of this structure are used internally by the core. Never use
     or modify them directly from the transport. */
 struct nn_pipebase {
@@ -154,6 +162,7 @@ struct nn_pipebase {
     void *data;
     struct nn_fsm_event in;
     struct nn_fsm_event out;
+    struct nn_ep_options options;
 };
 
 /*  Initialise the pipe.  */


### PR DESCRIPTION
The strategy is as discussed in IRC: move that options into substructure, and copy on endpoint creation.

I'm unsure for the set of options. IIRC Martin pointed that SNDBUF and RCVBUF should be there, but I think that buffer can be changed at runtime. I.e. if user does `setsockopt`, we change that option on every connection we have now. Does it make sense?

Also it may be desirable to add `NN_SOL_ENDPOINT` to make it clear which options are applied for next endpoint, and which are global for the socket.

Fixes #142. Unfortunately I couldn't reproduce it with unit test, but it's reproduced 100% either using nanoconfig or in name_service branch

The patch is submitted under MIT License
