### PR TITLE
Fix two race conditions in sinproc (fixes #114)

### DIFF
--- a/src/transports/inproc/sinproc.h
+++ b/src/transports/inproc/sinproc.h
@@ -33,11 +33,12 @@
 #include "../../utils/list.h"
 
 #define NN_SINPROC_CONNECT 1
-#define NN_SINPROC_ACCEPTED 2
-#define NN_SINPROC_SENT 3
-#define NN_SINPROC_RECEIVED 4
-#define NN_SINPROC_DISCONNECT 5
-#define NN_SINPROC_STOPPED 6
+#define NN_SINPROC_READY 2
+#define NN_SINPROC_ACCEPTED 3
+#define NN_SINPROC_SENT 4
+#define NN_SINPROC_RECEIVED 5
+#define NN_SINPROC_DISCONNECT 6
+#define NN_SINPROC_STOPPED 7
 
 /*  We use a random value here to prevent accidental clashes with the peer's
     internal source IDs. */


### PR DESCRIPTION
Includes (slighly modified) disconnection fix by David Beck (#164)

The handshake is done two-way for sinproc sockets first READY from A to B, then ACCEPTED from B to A. Instead of single ACCEPTED message. When READY is sent pipe is assumed to be able to receive messages but not yet attached to socket so can't send yet. This removes the race condition.

I'm not very sure about the disconnection fix, it seems ok, but It may leak memory somewhere probably.
