### PR TITLE
Fix warning for adding integer to string.

### DIFF
--- a/tools/options.c
+++ b/tools/options.c
@@ -189,7 +189,7 @@ static void nn_print_help (struct nn_parse_context *ctx, FILE *stream)
             }
         }
         if (optlen < 23) {
-            fputs ("                        " + optlen, stream);
+            fputs (&"                        "[optlen], stream);
             cursor = nn_print_line (stream, opt->description, 80-24);
         } else {
             cursor = opt->description;


### PR DESCRIPTION
Clang warns on this construct and suggests using array indexing
to silence the warning.
