### PR TITLE
Add clojure bindings link to documentation

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -65,6 +65,9 @@
 <p><a href="http://hackage.haskell.org/package/nanomsg-haskell">http://hackage.haskell.org/package/nanomsg-haskell</a></p>
 <p><a href="http://hackage.haskell.org/package/nanomsg">http://hackage.haskell.org/package/nanomsg</a></p>
 
+<h4>Clojure</h4>
+<p><a href="https://github.com/niwibe/jnanomsg">https://github.com/niwibe/jnanomsg</a></p>
+
 <h4>Java</h4>
 <p><a href="https://github.com/gonzus/jnano">https://github.com/gonzus/jnano</a></p>
 


### PR DESCRIPTION
I have one question. The new added link is clojure bindings, but also has java bindings. And I don't know if is good idea also add a link in java section.

Thanks for a fantastic work in nanomsg.
