### PR TITLE
Add attr.h file which is somehow lost in commit chain

### DIFF
--- a/src/utils/attr.h
+++ b/src/utils/attr.h
@@ -1,0 +1,32 @@
+/*
+    Copyright (c) 2013 Insollo Entertainment, LLC. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom
+    the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#ifndef NN_ATTR_INCLUDED
+#define NN_ATTR_INCLUDED
+
+#if defined __GNUC__ || defined __llvm__
+#define NN_UNUSED __attribute__ ((unused))
+#else
+#define NN_UNUSED
+#endif
+
+#endif


### PR DESCRIPTION
You somehow squashed my pull request #190 with bad commit name and lost `attr.h` file in the process. I think there is something wrong with your workflow. Let me know if I can help you.

In the meantime, this patch is submitted under MIT License.
