### PR TITLE
Fixed fd type in nn_poll on windows

### DIFF
--- a/src/core/poll.c
+++ b/src/core/poll.c
@@ -33,7 +33,7 @@ int nn_poll (struct nn_pollfd *fds, int nfds, int timeout)
     int rc;
     int i;
     fd_set fdset;
-    int fd;
+    SOCKET fd;
     int res;
     size_t sz;
     struct timeval tv;


### PR DESCRIPTION
On Windows I believe type of fd should be SOCKET not int in nn_poll.

Change submitted under MIT license.
