### PR TITLE
Fixed windows signalling bug (fixes #189)

### DIFF
--- a/src/core/sock.c
+++ b/src/core/sock.c
@@ -586,6 +586,7 @@ int nn_sock_send (struct nn_sock *self, struct nn_msg *msg, int flags)
             return -EINTR;
         errnum_assert (rc == 0, rc);
         nn_ctx_enter (&self->ctx);
+        self->flags |= NN_SOCK_FLAG_OUT;
 
         /*  If needed, re-compute the timeout to reflect the time that have
             already elapsed. */
@@ -658,6 +659,7 @@ int nn_sock_recv (struct nn_sock *self, struct nn_msg *msg, int flags)
             return -EINTR;
         errnum_assert (rc == 0, rc);
         nn_ctx_enter (&self->ctx);
+        self->flags |= NN_SOCK_FLAG_IN;
 
         /*  If needed, re-compute the timeout to reflect the time that have
             already elapsed. */


### PR DESCRIPTION
Assuming that there may be a lag between nn_efd_signal and the data
available in nn_efd_unsignal, we set NN_SOCK_FLAG_IN/OUT if we have a
sucessful return from nn_efd_wait. Setting this flag is safe at any
time. And I expect that it should not create a bottleneck

The patch is submitted under MIT License 
