### PR TITLE
Fix warnings

### DIFF
--- a/src/aio/poller_kqueue.inc
+++ b/src/aio/poller_kqueue.inc
@@ -80,7 +80,7 @@ void nn_poller_rm (struct nn_poller *self, struct nn_poller_hndl *hndl)
 
     /*  Invalidate any subsequent events on this file descriptor. */
     for (i = self->index; i != self->nevents; ++i)
-        if (self->events [i].ident == hndl->fd)
+        if (self->events [i].ident == (unsigned) hndl->fd)
             self->events [i].udata = (nn_poller_udata) NULL;
 }
 
@@ -113,7 +113,7 @@ void nn_poller_reset_in (struct nn_poller *self, struct nn_poller_hndl *hndl)
 
     /*  Invalidate any subsequent IN events on this file descriptor. */
     for (i = self->index; i != self->nevents; ++i)
-        if (self->events [i].ident == hndl->fd &&
+        if (self->events [i].ident == (unsigned) hndl->fd &&
               self->events [i].filter == EVFILT_READ)
             self->events [i].udata = (nn_poller_udata) NULL;
 }
@@ -147,7 +147,7 @@ void nn_poller_reset_out (struct nn_poller *self, struct nn_poller_hndl *hndl)
 
     /*  Invalidate any subsequent OUT events on this file descriptor. */
     for (i = self->index; i != self->nevents; ++i)
-        if (self->events [i].ident == hndl->fd &&
+        if (self->events [i].ident == (unsigned) hndl->fd &&
               self->events [i].filter == EVFILT_WRITE)
             self->events [i].udata = (nn_poller_udata) NULL;
 }

--- a/src/utils/efd_pipe.inc
+++ b/src/utils/efd_pipe.inc
@@ -96,7 +96,7 @@ void nn_efd_unsignal (struct nn_efd *self)
         if (nbytes < 0 && errno == EAGAIN)
             nbytes = 0;
         errno_assert (nbytes >= 0);
-        if (nn_fast (nbytes < sizeof (buf)))
+        if (nn_fast ((size_t) nbytes < sizeof (buf)))
             break;
     }
 }


### PR DESCRIPTION
Fix some warnings 

src/aio/poller_kqueue.inc:83:36: warning: comparison of integers of different signs: 'uintptr_t' (aka 'unsigned long') and 'int' [-Wsign-compare]
        if (self->events [i].ident == hndl->fd)
src/aio/poller_kqueue.inc:116:36: warning: comparison of integers of different signs: 'uintptr_t' (aka 'unsigned long') and 'int' [-Wsign-compare]
        if (self->events [i].ident == hndl->fd &&
src/aio/poller_kqueue.inc:150:36: warning: comparison of integers of different signs: 'uintptr_t' (aka 'unsigned long') and 'int' [-Wsign-compare]
        if (self->events [i].ident == hndl->fd &&

src/utils/efd_pipe.inc:99:29: warning: comparison of integers of different signs: 'ssize_t' (aka 'long') and 'unsigned long' [-Wsign-compare]
        if (nn_fast (nbytes < sizeof (buf)))
