### PR TITLE
Remove uint64_t format specifier warnings

### DIFF
--- a/src/core/global.c
+++ b/src/core/global.c
@@ -901,7 +901,7 @@ static void nn_global_submit_counter (int i, struct nn_sock *s,
 
     if(self.print_statistics) {
         fprintf(stderr, "nanomsg: socket.%s: %s: %llu\n",
-            s->socket_name, name, value);
+            s->socket_name, name, (long long unsigned int)value);
     }
 
     if (self.statistics_socket >= 0) {
@@ -916,11 +916,11 @@ static void nn_global_submit_counter (int i, struct nn_sock *s,
         if(*s->socket_name) {
             len = sprintf (buf, "ESTP:%s:%s:socket.%s:%s: %sZ 10 %llu:c",
                 self.hostname, self.appname, s->socket_name, name,
-                timebuf, value);
+                timebuf, (long long unsigned int)value);
         } else {
             len = sprintf (buf, "ESTP:%s:%s:socket.%d:%s: %sZ 10 %llu:c",
                 self.hostname, self.appname, i, name,
-                timebuf, value);
+                timebuf, (long long unsigned int)value);
         }
         nn_assert (len < (int)sizeof(buf));
         (void) nn_send (self.statistics_socket, buf, len, NN_DONTWAIT);


### PR DESCRIPTION
There are format build warnings present with GCC 4.8.1 on Linux.

```
src/core/global.c: In function ‘nn_global_submit_counter’:
src/core/global.c:904:13: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 5 has type ‘uint64_t’ [-Wformat=]
             s->socket_name, name, value);
             ^
src/core/global.c:919:17: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 8 has type ‘uint64_t’ [-Wformat=]
                 timebuf, value);
                 ^
src/core/global.c:923:17: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 8 has type ‘uint64_t’ [-Wformat=]
                 timebuf, value);
                 ^
```

This patch explicitly casts 'value' to match the format specifier, and results in a clean build.
