### PR TITLE
Fix for tcp_shutdown test // assertion in usock_win.inc

### DIFF
--- a/src/aio/usock_win.inc
+++ b/src/aio/usock_win.inc
@@ -430,6 +430,9 @@ static void nn_usock_shutdown (struct nn_fsm *self, int src, int type,
             return;
         }
 
+        /*  Notify our parent that pipe socket is shutting down  */
+        nn_fsm_raise (&usock->fsm, &usock->event_error, NN_USOCK_SHUTDOWN);
+
         /*  In all remaining states we'll simply cancel all overlapped
             operations. */
         if (nn_usock_cancel_io (usock) == 0)
@@ -600,6 +603,7 @@ static void nn_usock_handler (struct nn_fsm *self, int src, int type,
                 return;
             case NN_WORKER_OP_ERROR:
                 if (nn_usock_cancel_io (usock) == 0) {
+                    nn_fsm_raise(&usock->fsm, &usock->event_error, NN_USOCK_SHUTDOWN);
                     usock->state = NN_USOCK_STATE_DONE;
                     return;
                 }
@@ -615,6 +619,7 @@ static void nn_usock_handler (struct nn_fsm *self, int src, int type,
                 return;
             case NN_WORKER_OP_ERROR:
                 if (nn_usock_cancel_io (usock) == 0) {
+                    nn_fsm_raise(&usock->fsm, &usock->event_error, NN_USOCK_SHUTDOWN);
                     usock->state = NN_USOCK_STATE_DONE;
                     return;
                 }
@@ -627,6 +632,7 @@ static void nn_usock_handler (struct nn_fsm *self, int src, int type,
             switch (type) {
             case NN_USOCK_ACTION_ERROR:
                 if (nn_usock_cancel_io (usock) == 0) {
+                    nn_fsm_raise(&usock->fsm, &usock->event_error, NN_USOCK_SHUTDOWN);
                     usock->state = NN_USOCK_STATE_DONE;
                     return;
                 }


### PR DESCRIPTION
How to reproduce

<pre>
cmake <path to nanomsg>  -G"Visual Studio 11 Win64"
cmake --build . --config Debug
ctest -VV -C Debug
...
test 6
      Start  6: tcp_shutdown

6: Test command: C:\WORK\GITHUB\messaging\dev\build\Debug\tcp_shutdown.exe
6: Test timeout computed to be: 9.99988e+006
6: Assertion failed: 8 == NN_USOCK_STATE_ACTIVE (c:\work\github\messaging\dev\nanomsg\src\aio\usock_win.inc:326)
 6/29 Test  #6: tcp_shutdown .....................***Failed    3.42 sec
...
97% tests passed, 1 tests failed out of 29

Total Test time (real) =   9.76 sec

The following tests FAILED:
          6 - tcp_shutdown (Failed)
Errors while running CTest
</pre>


I've combined solution by @tailhook from #172 and  by @norsd from #211 
It will fix the issue with shutdown.
