### PR TITLE
save thread_routine return value

### DIFF
--- a/src/aio/worker_posix.inc
+++ b/src/aio/worker_posix.inc
@@ -29,7 +29,7 @@
 #include "../utils/attr.h"
 
 /*  Private functions. */
-static void nn_worker_routine (void *arg);
+static int nn_worker_routine (void *arg);
 
 void nn_worker_fd_init (struct nn_worker_fd *self, int src,
     struct nn_fsm *owner)
@@ -145,7 +145,7 @@ void nn_worker_execute (struct nn_worker *self, struct nn_worker_task *task)
     nn_mutex_unlock (&self->sync);
 }
 
-static void nn_worker_routine (void *arg)
+static int nn_worker_routine (void *arg)
 {
     int rc;
     struct nn_worker *self;
@@ -213,7 +213,7 @@ static void nn_worker_routine (void *arg)
                     /*  If the worker thread is asked to stop, do so. */
                     if (nn_slow (item == &self->stop)) {
                         nn_queue_term (&tasks);
-                        return;
+                        return -1;
                     }
 
                     /*  It's a user-defined task. Notify the user that it has
@@ -235,5 +235,6 @@ static void nn_worker_routine (void *arg)
             nn_ctx_leave (fd->owner->ctx);
         }
     }
+    return 0;
 }
 

--- a/src/aio/worker_win.inc
+++ b/src/aio/worker_win.inc
@@ -39,7 +39,7 @@
 const int nn_worker_stop = 0;
 
 /*  Private functions. */
-static void nn_worker_routine (void *arg);
+static int nn_worker_routine (void *arg);
 
 void nn_worker_task_init (struct nn_worker_task *self, int src,
     struct nn_fsm *owner)
@@ -129,7 +129,7 @@ HANDLE nn_worker_getcp (struct nn_worker *self)
     return self->cp;
 }
 
-static void nn_worker_routine (void *arg)
+static int nn_worker_routine (void *arg)
 {
     int rc;
     BOOL brc;
@@ -209,7 +209,7 @@ static void nn_worker_routine (void *arg)
             /*  Worker thread shutdown is requested. */
             if (nn_slow (entries [i].lpCompletionKey ==
                   (ULONG_PTR) &nn_worker_stop))
-                return;
+                return -1;
 
             /*  Process tasks. */
             task = (struct nn_worker_task*) entries [i].lpCompletionKey;
@@ -219,4 +219,5 @@ static void nn_worker_routine (void *arg)
             nn_ctx_leave (task->owner->ctx);
         }
     }
+    return 0;
 }

--- a/src/utils/thread.h
+++ b/src/utils/thread.h
@@ -25,7 +25,7 @@
 
 /*  Platform independent implementation of threading. */
 
-typedef void (nn_thread_routine) (void*);
+typedef int (nn_thread_routine) (void*);
 
 #if defined NN_HAVE_WINDOWS
 #include "thread_win.h"

--- a/src/utils/thread_posix.h
+++ b/src/utils/thread_posix.h
@@ -26,5 +26,6 @@ struct nn_thread
 {
     nn_thread_routine *routine;
     void *arg;
+    int rc;
     pthread_t handle;
 };

--- a/src/utils/thread_posix.inc
+++ b/src/utils/thread_posix.inc
@@ -41,7 +41,7 @@ static void *nn_thread_main_routine (void *arg)
     errnum_assert (rc == 0, rc);
 
     /*  Run the thread routine. */
-    self->routine (self->arg);
+    self->rc = self->routine (self->arg);
     return NULL;
 }
 

--- a/src/utils/thread_win.h
+++ b/src/utils/thread_win.h
@@ -26,5 +26,6 @@ struct nn_thread
 {
     nn_thread_routine *routine;
     void *arg;
+    int rc;
     HANDLE handle;
 };

--- a/src/utils/thread_win.inc
+++ b/src/utils/thread_win.inc
@@ -27,7 +27,7 @@ static unsigned int __stdcall nn_thread_main_routine (void *arg)
     struct nn_thread *self;
 
     self = (struct nn_thread*) arg;
-    self->routine (self->arg);
+    self->rc = self->routine (self->arg);
     return 0;
 }
 


### PR DESCRIPTION
sometimes we need to know the thread_routine running status, (we know that according to return values)
i always working on centos + xfce platform, can anyone test this patch on windows ? thanks
