### PR TITLE
Fix thread posix signal mask

### DIFF
--- a/src/utils/thread_posix.inc
+++ b/src/utils/thread_posix.inc
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012-2013 250bpm s.r.o.  All rights reserved.
+    Copyright (c) 2014 Achille Roussel All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
Hello,

As discussed on the mailing list, this patch changes the way the signal mask is set on the worker thread, so there's no chance for a race condition to happen if a signal happens to be handled by the newly created thread before its mask is set (because it inherits the signal mask from its parent).

I've ran the test suite and all tests passed, let me know if you want to see any changes made to this patch.

Cheers!
