### PR TITLE
fixed test invocation via ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ macro (add_libnanomsg_test NAME)
     list (APPEND all_tests ${NAME})
     add_executable (${NAME} tests/${NAME}.c)
     target_link_libraries (${NAME} nanomsg)
-    add_test (${NAME} ${NAME})
+    add_test (NAME ${NAME} COMMAND ${NAME})
 endmacro (add_libnanomsg_test)
 
 #  Transport tests.


### PR DESCRIPTION
With current syntax `add_test(testname Exename)` binary can't be found because it placed in CMAKE_BINARY_DIR[Debug|Release]

With new syntax `add_test(NAME <name> COMMAND <command> [arg1 [arg2 ...]])` 
COMMAND specifies an executable target (created by add_executable) will automatically be replaced by the location of the executable created at build time.

Ref: http://cmake.org/cmake/help/v2.8.12/cmake.html#command:add_test
