### PR TITLE
nn_msg_replace_body

### DIFF
--- a/src/utils/msg.c
+++ b/src/utils/msg.c
@@ -66,3 +66,9 @@ void nn_msg_bulkcopy_cp (struct nn_msg *dst, struct nn_msg *src)
     nn_chunkref_bulkcopy_cp (&dst->body, &src->body);
 }
 
+void nn_msg_replace_body(struct nn_msg *self, struct nn_chunkref newBody) 
+{
+    nn_chunkref_term(&self->body);
+    self->body = newBody;
+}
+

--- a/src/utils/msg.h
+++ b/src/utils/msg.h
@@ -62,5 +62,9 @@ void nn_msg_cp (struct nn_msg *dst, struct nn_msg *src);
 void nn_msg_bulkcopy_start (struct nn_msg *self, uint32_t copies);
 void nn_msg_bulkcopy_cp (struct nn_msg *dst, struct nn_msg *src);
 
+/** Replaces the message body with entirely new data.  This allows protocols
+    that substantially rewrite or preprocess the userland message to be written. */
+void nn_msg_replace_body(struct nn_msg *self, struct nn_chunkref newBody);
+
 #endif
 


### PR DESCRIPTION
Adding a new internal API nn_msg_replace_body to replace the body on a message while leaving the header intact.

This enhances the ability to create protocols that substantially preprocess or rewrite the underlying message during the send/receive process.

Signed-off-by: Drew Crawford drew@sealedabstract.com
