### PR TITLE
Fixed errno typo for EACCES

### DIFF
--- a/src/nn.h
+++ b/src/nn.h
@@ -136,8 +136,11 @@ extern "C" {
 #ifndef EFAULT
 #define EFAULT (NN_HAUSNUMERO + 16)
 #endif
+#ifndef EACCES
+#define EACCES (NN_HAUSNUMERO + 17)
+#endif
 #ifndef EACCESS
-#define EACCESS (NN_HAUSNUMERO + 17)
+#define EACCESS (EACCES)
 #endif
 #ifndef ENETRESET
 #define ENETRESET (NN_HAUSNUMERO + 18)

--- a/src/utils/err.c
+++ b/src/utils/err.c
@@ -74,7 +74,7 @@ const char *nn_err_strerror (int errnum)
         return "Too many open files";
     case EFAULT:
         return "Bad address";
-    case EACCESS:
+    case EACCES:
         return "Permission denied";
     case ENETRESET:
         return "Connection aborted by network";


### PR DESCRIPTION
I kept the EACCESS define around in case any binding is using it.

This code is licensed under MIT license.
