### PR TITLE
Extendable req/rep

### DIFF
--- a/src/protocols/reqrep/rep.c
+++ b/src/protocols/reqrep/rep.c
@@ -39,23 +39,6 @@
 
 #define NN_REP_INPROGRESS 1
 
-struct nn_rep {
-    struct nn_xrep xrep;
-    uint32_t flags;
-    struct nn_chunkref backtrace;
-};
-
-/*  Private functions. */
-static void nn_rep_init (struct nn_rep *self,
-    const struct nn_sockbase_vfptr *vfptr, void *hint);
-static void nn_rep_term (struct nn_rep *self);
-
-/*  Implementation of nn_sockbase's virtual functions. */
-static void nn_rep_destroy (struct nn_sockbase *self);
-static int nn_rep_events (struct nn_sockbase *self);
-static int nn_rep_send (struct nn_sockbase *self, struct nn_msg *msg);
-static int nn_rep_recv (struct nn_sockbase *self, struct nn_msg *msg);
-
 static const struct nn_sockbase_vfptr nn_rep_sockbase_vfptr = {
     NULL,
     nn_rep_destroy,

--- a/src/protocols/reqrep/rep.h
+++ b/src/protocols/reqrep/rep.h
@@ -24,7 +24,27 @@
 #define NN_REP_INCLUDED
 
 #include "../../protocol.h"
+#include "xrep.h"
 
 extern struct nn_socktype *nn_rep_socktype;
+
+
+struct nn_rep {
+    struct nn_xrep xrep;
+    uint32_t flags;
+    struct nn_chunkref backtrace;
+};
+
+/*  Some users may want to extend the REP protocol similar to how REP extends XREP.
+    Expose these methods to improve extensibility. */
+static void nn_rep_init (struct nn_rep *self,
+const struct nn_sockbase_vfptr *vfptr, void *hint);
+static void nn_rep_term (struct nn_rep *self);
+
+/*  Implementation of nn_sockbase's virtual functions. */
+static void nn_rep_destroy (struct nn_sockbase *self);
+static int nn_rep_events (struct nn_sockbase *self);
+static int nn_rep_send (struct nn_sockbase *self, struct nn_msg *msg);
+static int nn_rep_recv (struct nn_sockbase *self, struct nn_msg *msg);
 
 #endif

--- a/src/protocols/reqrep/req.c
+++ b/src/protocols/reqrep/req.c
@@ -63,60 +63,6 @@
 
 #define NN_REQ_SRC_RESEND_TIMER 1
 
-struct nn_req {
-
-    /*  The base class. Raw REQ socket. */
-    struct nn_xreq xreq;
-
-    /*  The state machine. */
-    struct nn_fsm fsm;
-    int state;
-
-    /*  ID of the request being currently processed. Replies for different
-        requests are considered stale and simply dropped. */
-    uint32_t reqid;
-
-    /*  Stored request, so that it can be re-sent if needed. */
-    struct nn_msg request;
-
-    /*  Stored reply, so that user can retrieve it later on. */
-    struct nn_msg reply;
-
-    /*  Timer used to wait while request should be re-sent. */
-    struct nn_timer timer;
-
-    /*  Protocol-specific socket options. */
-    int resend_ivl;
-
-    /*  Pipe the current request has been sent to. Non-null only in ACTIVE
-        state  */
-    struct nn_pipe *sent_to;
-};
-
-/*  Private functions. */
-static void nn_req_init (struct nn_req *self,
-    const struct nn_sockbase_vfptr *vfptr, void *hint);
-static void nn_req_term (struct nn_req *self);
-static int nn_req_inprogress (struct nn_req *self);
-static void nn_req_handler (struct nn_fsm *self, int src, int type,
-    void *srcptr);
-static void nn_req_shutdown (struct nn_fsm *self, int src, int type,
-    void *srcptr);
-static void nn_req_action_send (struct nn_req *self, int allow_delay);
-
-/*  Implementation of nn_sockbase's virtual functions. */
-static void nn_req_stop (struct nn_sockbase *self);
-static void nn_req_destroy (struct nn_sockbase *self);
-static void nn_req_in (struct nn_sockbase *self, struct nn_pipe *pipe);
-static void nn_req_out (struct nn_sockbase *self, struct nn_pipe *pipe);
-static int nn_req_events (struct nn_sockbase *self);
-static int nn_req_send (struct nn_sockbase *self, struct nn_msg *msg);
-static void nn_req_rm (struct nn_sockbase *self, struct nn_pipe *pipe);
-static int nn_req_recv (struct nn_sockbase *self, struct nn_msg *msg);
-static int nn_req_setopt (struct nn_sockbase *self, int level, int option,
-    const void *optval, size_t optvallen);
-static int nn_req_getopt (struct nn_sockbase *self, int level, int option,
-    void *optval, size_t *optvallen);
 static const struct nn_sockbase_vfptr nn_req_sockbase_vfptr = {
     nn_req_stop,
     nn_req_destroy,

--- a/src/protocols/reqrep/req.h
+++ b/src/protocols/reqrep/req.h
@@ -24,7 +24,67 @@
 #define NN_REQ_INCLUDED
 
 #include "../../protocol.h"
+#include "xreq.h"
+#include "../../aio/fsm.h"
+#include "../../aio/timer.h"
+
+
+struct nn_req {
+
+    /*  The base class. Raw REQ socket. */
+    struct nn_xreq xreq;
+
+    /*  The state machine. */
+    struct nn_fsm fsm;
+    int state;
+
+    /*  ID of the request being currently processed. Replies for different
+        requests are considered stale and simply dropped. */
+    uint32_t reqid;
+
+    /*  Stored request, so that it can be re-sent if needed. */
+    struct nn_msg request;
+
+    /*  Stored reply, so that user can retrieve it later on. */
+    struct nn_msg reply;
+
+    /*  Timer used to wait while request should be re-sent. */
+    struct nn_timer timer;
+
+    /*  Protocol-specific socket options. */
+    int resend_ivl;
+
+    /*  Pipe the current request has been sent to. Non-null only in ACTIVE
+        state  */
+    struct nn_pipe *sent_to;
+};
 
 extern struct nn_socktype *nn_req_socktype;
+
+/*  Some users may want to extend the REQ protocol similar to how REQ extends XREQ.
+    Expose these methods to improve extensibility. */
+static void nn_req_init (struct nn_req *self,
+    const struct nn_sockbase_vfptr *vfptr, void *hint);
+static void nn_req_term (struct nn_req *self);
+static int nn_req_inprogress (struct nn_req *self);
+static void nn_req_handler (struct nn_fsm *self, int src, int type,
+    void *srcptr);
+static void nn_req_shutdown (struct nn_fsm *self, int src, int type,
+    void *srcptr);
+static void nn_req_action_send (struct nn_req *self, int allow_delay);
+
+/*  Implementation of nn_sockbase's virtual functions. */
+static void nn_req_stop (struct nn_sockbase *self);
+static void nn_req_destroy (struct nn_sockbase *self);
+static void nn_req_in (struct nn_sockbase *self, struct nn_pipe *pipe);
+static void nn_req_out (struct nn_sockbase *self, struct nn_pipe *pipe);
+static int nn_req_events (struct nn_sockbase *self);
+static int nn_req_send (struct nn_sockbase *self, struct nn_msg *msg);
+static void nn_req_rm (struct nn_sockbase *self, struct nn_pipe *pipe);
+static int nn_req_recv (struct nn_sockbase *self, struct nn_msg *msg);
+static int nn_req_setopt (struct nn_sockbase *self, int level, int option,
+    const void *optval, size_t optvallen);
+static int nn_req_getopt (struct nn_sockbase *self, int level, int option,
+    void *optval, size_t *optvallen);
 
 #endif


### PR DESCRIPTION
Per previous discussion, some users may want to extend req/rep the same way REP extends XREP/XREQ.  Exposing the necessary plumbing to do that more effectively.

For a longer discussion of this change, see http://www.freelists.org/post/nanomsg/nn-req-extension
