### PR TITLE
Fix overlapped I/O on Windows. Provide a test.

### DIFF
--- a/src/aio/usock_win.inc
+++ b/src/aio/usock_win.inc
@@ -399,7 +399,7 @@ void nn_usock_send (struct nn_usock *self, const struct nn_iovec *iov,
             idx += iov [i].iov_len;
         }
         brc = WriteFile (self->p, self->pipesendbuf, len, NULL, &self->out.olpd);
-        if (nn_fast (brc)) {
+        if (nn_fast (brc || GetLastError() == ERROR_IO_PENDING)) {
             nn_worker_op_start (&self->out, 0);
             return;
         }

--- a/tests/ipc.c
+++ b/tests/ipc.c
@@ -38,6 +38,9 @@ int main ()
     int i;
     int s1, s2;
 
+	size_t size;
+	char * buf;
+
     /*  Try closing a IPC socket while it not connected. */
     sc = test_socket (AF_SP, NN_PAIR);
     test_connect (sc, SOCKET_ADDRESS);
@@ -68,6 +71,17 @@ int main ()
     for (i = 0; i != 100; ++i) {
         test_recv (sb, "XYZ");
     }
+
+	/*  Send something large enough to trigger overlapped I/O on Windows. */
+	size = 10000;
+	buf = malloc( size );
+	for (i =0; i != size - 1; ++i) {
+		buf[i] = 48 + i % 10;
+	}
+	buf[size-1] = '\0';
+	test_send (sc, buf);
+	test_recv (sb, buf);
+	free( buf );
 
     test_close (sc);
     test_close (sb);


### PR DESCRIPTION
The new Windows Named Pipe IPC code will not handle overlapped I/O correctly. Updated the unit test as well. Our buffers were small enough that overlapped never triggered, so we didn't see this.
