### PR TITLE
Fixing generation of diagrams (via 'make diagrams') when build tree is o...

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -554,6 +554,6 @@ EXTRA_DIST += \
 
 diagrams:
 	-mkdir -p doc/diagrams
-	./doc/diag.py $(DEFS) $(CPPFLAGS) \
+	$(abs_srcdir)/doc/diag.py $(DEFS) $(CPPFLAGS) \
 		$(shell clang -E - -v < /dev/null 2>&1 | \
 			sed -n '/#include </{:x;n;/^End/q;s/^ */-I/;p;bx}')

--- a/doc/diag.py
+++ b/doc/diag.py
@@ -322,11 +322,12 @@ def main():
     global index
 
     index = Index.create()
+    script_dir = os.path.abspath(os.path.dirname(os.path.realpath(sys.argv[0])) + '/../')
 
     with open('doc/diagrams.html', 'wt') as f:
         sys.stdout = f
         print(HTML_HEADER)
-        for dirpath, dirs, files in os.walk('src'):
+        for dirpath, dirs, files in os.walk(os.path.join(script_dir,'src' )):
             for f in files:
                 if not f.endswith('.c'):
                     continue


### PR DESCRIPTION
...ther than source tree.

hi there Martin, 
this is a simple patch for allowing generation of diagrams when building in other directory than the root dir of nanomsg. 

Thanks! 
