### PR TITLE
port ipc_stress to Windows

### DIFF
--- a/src/utils/atomic.h
+++ b/src/utils/atomic.h
@@ -23,8 +23,6 @@
 #ifndef NN_ATOMIC_INCLUDED
 #define NN_ATOMIC_INCLUDED
 
-#include "../nn.h"
-
 #if defined NN_HAVE_WINDOWS
 #include "win.h"
 #define NN_ATOMIC_WINAPI
@@ -48,16 +46,16 @@ struct nn_atomic {
 };
 
 /*  Initialise the object. Set it to value 'n'. */
-NN_EXPORT void nn_atomic_init (struct nn_atomic *self, uint32_t n);
+void nn_atomic_init (struct nn_atomic *self, uint32_t n);
 
 /*  Destroy the object. */
-NN_EXPORT void nn_atomic_term (struct nn_atomic *self);
+void nn_atomic_term (struct nn_atomic *self);
 
 /*  Atomically add n to the object, return old value of the object. */
-NN_EXPORT uint32_t nn_atomic_inc (struct nn_atomic *self, uint32_t n);
+uint32_t nn_atomic_inc (struct nn_atomic *self, uint32_t n);
 
 /*  Atomically subtract n from the object, return old value of the object. */
-NN_EXPORT uint32_t nn_atomic_dec (struct nn_atomic *self, uint32_t n);
+uint32_t nn_atomic_dec (struct nn_atomic *self, uint32_t n);
 
 #endif
 

--- a/tests/ipc_stress.c
+++ b/tests/ipc_stress.c
@@ -29,6 +29,7 @@
 #include "testutil.h"
 #include "../src/utils/thread.c"
 #include "../src/utils/atomic.h"
+#include "../src/utils/atomic.c"
 
 /*  Stress test the IPC transport. */
 


### PR DESCRIPTION
This adds ipc_stress to cmake and fixes the code to compile on Windows. The test doesn't pass, but this is a step :)
