### PR TITLE
This implements a new socket option at global level NN_PARSE_PIPE_TYPE,

### DIFF
--- a/doc/nn_getsockopt.txt
+++ b/doc/nn_getsockopt.txt
@@ -108,6 +108,16 @@ _<nanomsg/nn.h>_ header defines generic socket-level options
     Socket name for error reporting and statistics. The type of the option
     is string. Default value is "N" where N is socket integer.
     *This option is experimental, see linknanomsg:nn_env[7] for details*
+*NN_PARSE_PIPE_TYPE*::
+    Returns data about whether the underlying transport uses _NN_PIPE_PARSED_.
+    If so, certain control information may not be available for custom devices.
+    _NN_PARSE_PIPE_TYPE_UNKNOWN_ indicates that no information is available,
+    _NN_PARSE_PIPE_TYPE_UNPARSED_ suggests that an unparsed scheme is used,
+    _NN_PARSE_PIPE_TYPE_PARSED_ suggests that a parsed scheme is used,
+    _NN_PARSE_PIPE_TYPE_MIXED_ suggests that both schemes may be used.
+    The implementation is sticky; if a PARSED transport has ever been
+    used with the socket, PARSED or MIXED will be returned, even if
+    the PARSED transport is subsequently closed.
 
 
 RETURN VALUE

--- a/src/core/sock.h
+++ b/src/core/sock.h
@@ -136,6 +136,9 @@ struct nn_sock
 
     /*  The socket name for statistics  */
     char socket_name[64];
+
+    /* the type of parsing for the socket */
+    char socket_parse_type;
 };
 
 /*  Initialise the socket. */

--- a/src/nn.h
+++ b/src/nn.h
@@ -353,6 +353,16 @@ NN_INLINE struct nn_cmsghdr *nn_cmsg_nexthdr_ (const struct nn_msghdr *mhdr,
 #define NN_PROTOCOL 13
 #define NN_IPV4ONLY 14
 #define NN_SOCKET_NAME 15
+#define NN_PARSE_PIPE_TYPE 16
+
+/*The socket's parse type isn't known (e.g. no transport specified) */
+#define NN_PARSE_PIPE_TYPE_UNKNOWN -1
+/* The socket doesn't parse the pipe. (e.g. ipc, tcp) */
+#define NN_PARSE_PIPE_TYPE_UNPARSED 0
+/*The socket parses the pipe (e.g. inproc) */
+#define NN_PARSE_PIPE_TYPE_PARSED 1
+/*The socket may or may not parse the pipe (e.g. mix of unparsed and parsed types) */
+#define NN_PARSE_PIPE_TYPE_MIXED 2
 
 /*  Send/recv options.                                                        */
 #define NN_DONTWAIT 1


### PR DESCRIPTION
suggesting whether NN_PIPE_PARSED will be used for messages on the socket.

This API is proposed to solve the problem described on the mailing list here: http://www.freelists.org/post/nanomsg/header-behavior-for-ipc-vs-inproc,2

Signed-off-by: Drew Crawford drew@sealedabstract.com
