### PR TITLE
Remove `inline` keyword to make code ANSI C compatible. Closes #297.

### DIFF
--- a/doc/nn_cmsg.txt
+++ b/doc/nn_cmsg.txt
@@ -57,7 +57,7 @@ while (hdr != NULL) {
     printf ("level: %d property: %d length: %dB data: ",
         (int) hdr->cmsg_level,
         (int) hdr->cmsg_type,
-        (int) len));
+        (int) len);
     unsigned char *data = NN_CMSG_DATA(hdr);
     while (len) {
         printf ("%02X", *data);

--- a/src/core/global.c
+++ b/src/core/global.c
@@ -436,6 +436,18 @@ int nn_freemsg (void *msg)
     return 0;
 }
 
+struct nn_cmsghdr *nn_cmsg_nexthdr_ (const struct nn_msghdr *mhdr,
+    const struct nn_cmsghdr *cmsg)
+{
+    size_t sz;
+
+    sz = sizeof (struct nn_cmsghdr) + cmsg->cmsg_len;
+    if (((char*) cmsg) - ((char*) mhdr->msg_control) + sz >=
+           mhdr->msg_controllen)
+        return NULL;
+    return (struct nn_cmsghdr*) (((char*) cmsg) + sz);
+}
+
 int nn_global_create_socket (int domain, int protocol)
 {
     int rc;

--- a/src/nn.h
+++ b/src/nn.h
@@ -53,14 +53,6 @@ extern "C" {
 #   endif
 #endif
 
-/*  Inline functions are everywhere, but MSVC requires underscores           */
-#if defined _WIN32
-#  define NN_INLINE static __inline
-#else
-#  define NN_INLINE static inline
-#endif
-
-
 /******************************************************************************/
 /*  ABI versioning support.                                                   */
 /******************************************************************************/
@@ -291,18 +283,9 @@ struct nn_cmsghdr {
 };
 
 /*  Internal function. Not to be used directly.                               */
-/*  Use NN_CMSG_NEXTHDR macro instead.                                        */
-NN_INLINE struct nn_cmsghdr *nn_cmsg_nexthdr_ (const struct nn_msghdr *mhdr,
-    const struct nn_cmsghdr *cmsg)
-{
-    size_t sz;
-
-    sz = sizeof (struct nn_cmsghdr) + cmsg->cmsg_len;
-    if (((char*) cmsg) - ((char*) mhdr->msg_control) + sz >=
-           mhdr->msg_controllen)
-        return NULL;
-    return (struct nn_cmsghdr*) (((char*) cmsg) + sz);
-}
+/*  Use NN_CMSG_NXTHDR macro instead.                                         */
+struct nn_cmsghdr *nn_cmsg_nexthdr_ (const struct nn_msghdr *mhdr,
+    const struct nn_cmsghdr *cmsg);
 
 #define NN_CMSG_FIRSTHDR(mhdr) \
     ((mhdr)->msg_controllen >= sizeof (struct nn_cmsghdr) \


### PR DESCRIPTION
The function nn_cmsg_nexthdr_ was the only inline function. It is
moved to global.c.
