### PR TITLE
Tcp shutdown internal 216

### DIFF
--- a/src/core/sock.c
+++ b/src/core/sock.c
@@ -824,12 +824,21 @@ static void nn_sock_shutdown (struct nn_fsm *self, int src, int type,
     }
     if (nn_slow (sock->state == NN_SOCK_STATE_STOPPING_EPS)) {
 
-        /*  Endpoint is stopped. Now we can safely deallocate it. */
-        nn_assert (src == NN_SOCK_SRC_EP && type == NN_EP_STOPPED);
-        ep = (struct nn_ep*) srcptr;
-        nn_list_erase (&sock->sdeps, &ep->item);
-        nn_ep_term (ep);
-        nn_free (ep);
+		/*  Endpoint is stopped. Now we can safely deallocate it. */
+		if ( src != NN_SOCK_SRC_EP || type != NN_EP_STOPPED ) {
+			/*
+				tcp_shutdown test on Windows triggers this with low reproduction.
+				src == 0, type == 33988
+				The sdeps list isn't empty, doesn't contain the item, but just doing an early return will let the test finish successfully.
+			*/
+			fprintf (stderr, "nn_sock_shutdown: unexpected fsm event src %d type %d\n", src, type);
+			return;
+		} else {
+			ep = (struct nn_ep*) srcptr;
+			nn_list_erase (&sock->sdeps, &ep->item);
+			nn_ep_term (ep);
+			nn_free (ep);
+		}
 
 finish2:
         /*  If all the endpoints are deallocated, we can start stopping


### PR DESCRIPTION
This gross hack avoids the tcp_shutdown test failure on Windows. It also fixes an abort during shutdown that we encountered in our internal product while using the ipc transport (our internal bug had lower repro, but wasn't as pathological as the tcp_shutdown test - still, it was the same issue).

I'm not suggesting that this be merged, but I'm hoping someone can provide some insight as to what is going on (e.g. what is a non NN_SOCK_SRC_EP doing here) and point towards a better fix.
