### PR TITLE
Update nn_pubsub.txt

### DIFF
--- a/doc/nn_pubsub.txt
+++ b/doc/nn_pubsub.txt
@@ -36,6 +36,9 @@ Topic with zero length matches any message.
 If the socket is subscribed to multiple topics, message matching any of them
 will be delivered to the user.
 
+Since the filtering is performed on the Subscriber side, all the messages 
+from Publisher will be sent over the transport layer. 
+
 The entire message, including the topic, is delivered to the user.
 
 Socket Types


### PR DESCRIPTION
Hi, current explanation of how pubsub works doesn't cover the fact that Pub socket actually sends all the messages over the wire, even if the subscriber isn't interested in receiving them. 

I'm not sure what could be the best wording. Using word "deliver" would be wrong in that case, since it's used to specify actual message delivery from `recv`. So I thought that saying that they are sent over the transport layer (since it's not always network, I thought it would also be a bad wording) is just about right, since it is sent over, but not "delivered".

It also looks like I'm not the only one who was interested in that question (there were questions in mailing list and around Internet).

Thanks for the great lib, btw!
