### PR TITLE
Add missing device.h file to dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,8 @@ NANOMSG_CORE = \
     src/core/symbol.c
 
 NANOMSG_DEVICES =\
-    src/devices/device.c
+    src/devices/device.c \
+    src/devices/device.h
 
 
 NANOMSG_AIO = \


### PR DESCRIPTION
Add src/devices/device.h to Makefile.am to fix broken "make dist" build.
