### PR TITLE
Nanocat discards the reply from the REP socket.

### DIFF
--- a/tools/nanocat.c
+++ b/tools/nanocat.c
@@ -510,7 +510,7 @@ void nn_recv_loop (nn_options_t *options, int sock)
         rc = nn_recv (sock, &buf, NN_MSG, 0);
         if (rc < 0 && errno == EAGAIN) {
             continue;
-        } else if (errno == ETIMEDOUT || errno == EFSM) {
+        } else if (rc < 0 && (errno == ETIMEDOUT || errno == EFSM)) {
             return;  /*  No more messages possible  */
         } else {
             nn_assert_errno (rc >= 0, "Can't recv");


### PR DESCRIPTION
```
nanocat --rep --bind tcp://127.0.0.1:1234 --data pong --format ascii
nanocat --req --connect tcp://127.0.0.1:1234 --data ping --format ascii
```

I guess because the socket is already in a closed state after the server sends its reply, the client never outputs the 'pong' message.

The attached commit fixes the problem, but since I'm new to nanomsg I don't know if this is the appropriate way to solve the issue.
