### PR TITLE
CMake Windows Build missing INT_MAX

### DIFF
--- a/src/aio/usock_win.inc
+++ b/src/aio/usock_win.inc
@@ -29,6 +29,7 @@
 
 #include <stddef.h>
 #include <string.h>
+#include <limits.h>
 
 #define NN_USOCK_STATE_IDLE 1
 #define NN_USOCK_STATE_STARTING 2


### PR DESCRIPTION
as mentioned in #330 there seems to be a missing include in the windows version of usock

```
In file included from C:\work\nanomsg\nanomsg\src\aio\../utils/err.h:33:0,
                 from C:\work\nanomsg\nanomsg\src\aio\usock_win.inc:26,
                 from C:\work\nanomsg\nanomsg\src\aio\usock.c:26:
C:\work\nanomsg\nanomsg\src\aio\usock_win.inc: In function 'nn_usock_setsockopt':
C:\work\nanomsg\nanomsg\src\aio\usock_win.inc:193:25: error: 'INT_MAX' undeclared (first use in this function)
     nn_assert (optlen < INT_MAX);
```

submitted under MIT as always

Signed-off-by: Tobias Peters tobias.peters@kreativeffekt.at
