### PR TITLE
Remove a duplicate include in core/global.c

### DIFF
--- a/src/core/global.c
+++ b/src/core/global.c
@@ -74,7 +74,6 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdlib.h>
 #include <time.h>
 
 #if defined NN_HAVE_MINGW


### PR DESCRIPTION
This is the most minor change possible, but it was bugging me.
