### PR TITLE
Documentation fix on sample source code

### DIFF
--- a/doc/nn_symbol_info.txt
+++ b/doc/nn_symbol_info.txt
@@ -135,7 +135,7 @@ for (i = 0; ; ++i) {
     if(rc == 0)
         break;
     assert (rc == sizeof (sym));
-    printf ("'%s' = %d\n", sym->name, sym->value);
+    printf ("'%s' = %d\n", sym.name, sym.value);
 }
 ----
 


### PR DESCRIPTION
The example code doesn't compile without this patch as sym isn't a pointer.
