### PR TITLE
Fix locking bug in nn_global_submit_statistics()

### DIFF
--- a/src/core/global.c
+++ b/src/core/global.c
@@ -1124,10 +1124,14 @@ static void nn_global_submit_statistics ()
 
         nn_glock_lock ();
         s = self.socks [i];
-        if (!s)
+        if (!s) {
+            nn_glock_unlock ();
             continue;
-        if (i == self.statistics_socket)
+        }
+        if (i == self.statistics_socket) {
+            nn_glock_unlock ();
             continue;
+        }
         nn_ctx_enter (&s->ctx);
         nn_glock_unlock ();
 


### PR DESCRIPTION
Notes on this pull:

I couldn't immediately find a style guide or pointers on how to submit patches, please let me know if I need to do anything special. I'll probably send an email to the mailing list pointing to this pull request.

I'm baffled as to how the existing code would not result in a locked condition and broken code on all platforms (instead of just on OSX), so I might be missing something with this patch.

---

nn_global_submit_statistics() had a locking bug where a nn_glock_lock()
does not always get nn_glock_unlocked().

This appears to fix issue #341 ("SUB fails after ~tens of seconds on OSX
10.10 (Yosemite)") in which socket communication fails after 10 seconds
on OSX. nn_global_submit_statistics() is called every 10 seconds by
default.

Signed-off-by: bryan newbold bnewbold@twinleaf.com
