### PR TITLE
support a callback to intercept fprintf(stderr, into custom handlers

### DIFF
--- a/src/nn.h
+++ b/src/nn.h
@@ -244,6 +244,10 @@ struct nn_symbol_properties {
 NN_EXPORT int nn_symbol_info (int i,
     struct nn_symbol_properties *buf, int buflen);
 
+/*  Register a callback to receive error messages before asserts and aborts.  */
+typedef void (*nn_err_log_callback_t) (const char *fmt, va_list args);
+NN_EXPORT void nn_err_log_callback (nn_err_log_callback_t callback);
+
 /******************************************************************************/
 /*  Helper function for shutting down multi-threaded applications.            */
 /******************************************************************************/

--- a/src/utils/err.c
+++ b/src/utils/err.c
@@ -186,3 +186,22 @@ void nn_win_error (int err, char *buf, size_t bufsize)
 
 #endif
 
+static nn_err_log_callback_t err_log_callback = NULL;
+
+void nn_err_log ( const char * fmt, ... ) {
+    va_list argp;
+    if ( err_log_callback != NULL ) {
+        va_start (argp, fmt);
+        err_log_callback (fmt, argp);
+        va_end (argp);
+        return;
+    }
+	va_start (argp, fmt);
+	vfprintf (stderr, fmt, argp);
+	va_end (argp);
+	fflush (stderr);
+}
+
+void nn_err_log_callback (nn_err_log_callback_t callback) {
+    err_log_callback = callback;
+}

--- a/src/utils/err.h
+++ b/src/utils/err.h
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdarg.h>
 
 /*  Include nn.h header to define nanomsg-specific error codes. */
 #include "../nn.h"
@@ -40,14 +41,16 @@
 #define NN_NORETURN
 #endif
 
+void nn_err_log ( const char * fmt, ... );
+
 /*  Same as system assert(). However, under Win32 assert has some deficiencies.
     Thus this macro. */
 #define nn_assert(x) \
     do {\
         if (nn_slow (!(x))) {\
-            fprintf (stderr, "Assertion failed: %s (%s:%d)\n", #x, \
-                __FILE__, __LINE__);\
-            fflush (stderr);\
+			nn_err_log ( \
+				"Assertion failed: %s (%s:%d)\n", #x, \
+				__FILE__, __LINE__);\
             nn_err_abort ();\
         }\
     } while (0)
@@ -55,11 +58,10 @@
 #define nn_assert_state(obj, state_name) \
     do {\
         if (nn_slow ((obj)->state != state_name)) {\
-            fprintf (stderr, \
+			nn_err_log ( \
                 "Assertion failed: %d == %s (%s:%d)\n", \
                 (obj)->state, #state_name, \
                 __FILE__, __LINE__);\
-            fflush (stderr);\
             nn_err_abort ();\
         }\
     } while (0)
@@ -68,9 +70,8 @@
 #define alloc_assert(x) \
     do {\
         if (nn_slow (!x)) {\
-            fprintf (stderr, "Out of memory (%s:%d)\n",\
+            nn_err_log ( "Out of memory (%s:%d)\n",\
                 __FILE__, __LINE__);\
-            fflush (stderr);\
             nn_err_abort ();\
         }\
     } while (0)
@@ -79,9 +80,8 @@
 #define errno_assert(x) \
     do {\
         if (nn_slow (!(x))) {\
-            fprintf (stderr, "%s [%d] (%s:%d)\n", nn_err_strerror (errno),\
+            nn_err_log ( "%s [%d] (%s:%d)\n", nn_err_strerror (errno),\
                 (int) errno, __FILE__, __LINE__);\
-            fflush (stderr);\
             nn_err_abort ();\
         }\
     } while (0)
@@ -90,9 +90,8 @@
 #define errnum_assert(cond, err) \
     do {\
         if (nn_slow (!(cond))) {\
-            fprintf (stderr, "%s [%d] (%s:%d)\n", nn_err_strerror (err),\
+            nn_err_log ( "%s [%d] (%s:%d)\n", nn_err_strerror (err),\
                 (int) (err), __FILE__, __LINE__);\
-            fflush (stderr);\
             nn_err_abort ();\
         }\
     } while (0)
@@ -103,9 +102,8 @@
         if (nn_slow (!(x))) {\
             char errstr [256];\
             nn_win_error ((int) GetLastError (), errstr, 256);\
-            fprintf (stderr, "%s [%d] (%s:%d)\n",\
+            nn_err_log ( "%s [%d] (%s:%d)\n",\
                 errstr, (int) GetLastError (), __FILE__, __LINE__);\
-            fflush (stderr);\
             nn_err_abort ();\
         }\
     } while (0)
@@ -116,9 +114,8 @@
         if (nn_slow (!(x))) {\
             char errstr [256];\
             nn_win_error (WSAGetLastError (), errstr, 256);\
-            fprintf (stderr, "%s [%d] (%s:%d)\n",\
+            nn_err_log ( "%s [%d] (%s:%d)\n",\
                 errstr, (int) WSAGetLastError (), __FILE__, __LINE__);\
-            fflush (stderr);\
             nn_err_abort ();\
         }\
     } while (0)
@@ -126,9 +123,8 @@
 /*  Assertion-like macros for easier fsm debugging. */
 #define nn_fsm_error(message, state, src, type) \
     do {\
-        fprintf (stderr, "%s: state=%d source=%d action=%d (%s:%d)\n", \
+        nn_err_log ( "%s: state=%d source=%d action=%d (%s:%d)\n", \
             message, state, src, type, __FILE__, __LINE__);\
-        fflush (stderr);\
         nn_err_abort ();\
     } while (0)
 


### PR DESCRIPTION
This simple change adds a nn_err_log_callback function to register a callback and receive error messages before the nanomsg library goes into an assert or an abort. This is useful to us as those messages are otherwise lost and not available on our application's crash logs.
