### PR TITLE
Support setting security attributes on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ add_libnanomsg_test (separation)
 add_libnanomsg_test (zerocopy)
 add_libnanomsg_test (shutdown)
 add_libnanomsg_test (cmsg)
+add_libnanomsg_test (win_sec_attr)
 
 #  Build the performance tests.
 

--- a/src/aio/usock_win.h
+++ b/src/aio/usock_win.h
@@ -75,6 +75,13 @@ struct nn_usock {
     /*  For now we allocate a new buffer for each write to a named pipe. */
     void *pipesendbuf;
 
+    /* Pointer to security attribute*/
+    SECURITY_ATTRIBUTES sec_attr;
+
+    /* Out Buffer and In Buffer size */
+    int outbuffersz;
+    int inbuffersz;
+
     /*  Errno remembered in NN_USOCK_ERROR state  */
     int errnum;
 };

--- a/src/aio/usock_win.inc
+++ b/src/aio/usock_win.inc
@@ -93,6 +93,11 @@ void nn_usock_init (struct nn_usock *self, int src, struct nn_fsm *owner)
     /* NamedPipe-related stuff. */
     memset (&self->pipename, 0, sizeof (self->pipename));
     self->pipesendbuf = NULL;
+    memset (&self->sec_attr, 0, sizeof (SECURITY_ATTRIBUTES));
+
+    /* default size for both in and out buffers is 4096*/
+    self->outbuffersz = 4096;
+    self->inbuffersz = 4096;
 }
 
 void nn_usock_term (struct nn_usock *self)
@@ -501,7 +506,6 @@ static void nn_usock_create_io_completion (struct nn_usock *self)
 static void nn_usock_create_pipe (struct nn_usock *self, const char *name)
 {
     char fullname [256];
-
     /*  First, create a fully qualified name for the named pipe. */
     _snprintf(fullname, sizeof (fullname), "\\\\.\\pipe\\%s", name);
 
@@ -513,10 +517,10 @@ static void nn_usock_create_pipe (struct nn_usock *self, const char *name)
         PIPE_TYPE_BYTE | PIPE_READMODE_BYTE |
             PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
         PIPE_UNLIMITED_INSTANCES,
-        4096,
-        4096,
+        self->outbuffersz,
+        self->inbuffersz,
         0,
-        NULL);
+        &self->sec_attr);
 
     /* TODO: How to properly handle self->p == INVALID_HANDLE_VALUE? */
     win_assert (self->p != INVALID_HANDLE_VALUE);
@@ -543,7 +547,7 @@ DWORD nn_usock_open_pipe (struct nn_usock *self, const char *name)
         NULL,
         OPEN_ALWAYS,
         FILE_FLAG_OVERLAPPED,
-        NULL);
+        &self->sec_attr);
 
     if (self->p == INVALID_HANDLE_VALUE)
         return GetLastError ();

--- a/src/aio/usock_win.inc
+++ b/src/aio/usock_win.inc
@@ -509,8 +509,6 @@ static void nn_usock_create_pipe (struct nn_usock *self, const char *name)
     /*  First, create a fully qualified name for the named pipe. */
     _snprintf(fullname, sizeof (fullname), "\\\\.\\pipe\\%s", name);
 
-    /* TODO: Expose custom nOutBufferSize, nInBufferSize, nDefaultTimeOut,
-             lpSecurityAttributes */
     self->p = CreateNamedPipeA (
         (char*) fullname,
         PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
@@ -522,7 +520,6 @@ static void nn_usock_create_pipe (struct nn_usock *self, const char *name)
         0,
         &self->sec_attr);
 
-    /* TODO: How to properly handle self->p == INVALID_HANDLE_VALUE? */
     win_assert (self->p != INVALID_HANDLE_VALUE);
 
     self->isaccepted = 1;
@@ -539,15 +536,14 @@ DWORD nn_usock_open_pipe (struct nn_usock *self, const char *name)
     /*  First, create a fully qualified name for the named pipe. */
     _snprintf(fullname, sizeof (fullname), "\\\\.\\pipe\\%s", name);
 
-    /* TODO: Expose a way to pass lpSecurityAttributes */
     self->p = CreateFileA (
         fullname,
         GENERIC_READ | GENERIC_WRITE,
         0,
-        NULL,
+        &self->sec_attr,
         OPEN_ALWAYS,
         FILE_FLAG_OVERLAPPED,
-        &self->sec_attr);
+        0);
 
     if (self->p == INVALID_HANDLE_VALUE)
         return GetLastError ();

--- a/src/core/sock.c
+++ b/src/core/sock.c
@@ -155,6 +155,8 @@ int nn_sock_init (struct nn_sock *self, struct nn_socktype *socktype, int fd)
     /* Security attribute*/
     self->sec_attr = NULL;
     self->sec_attr_size = 0;
+    self->inbuffersz = 4096;
+    self->outbuffersz = 4096;
 
     /*  The transport-specific options are not initialised immediately,
         rather, they are allocated later on when needed. */

--- a/src/core/sock.h
+++ b/src/core/sock.h
@@ -141,9 +141,9 @@ struct nn_sock
     void*	sec_attr;
     size_t	sec_attr_size;
 
-	/* Out Buffer and In Buffer size */
-	int outbuffersz;
-	int inbuffersz;
+    /* Out Buffer and In Buffer size */
+    int outbuffersz;
+    int inbuffersz;
 
 };
 

--- a/src/core/sock.h
+++ b/src/core/sock.h
@@ -136,6 +136,15 @@ struct nn_sock
 
     /*  The socket name for statistics  */
     char socket_name[64];
+
+    /* Win32 Security Attribute */
+    void*	sec_attr;
+    size_t	sec_attr_size;
+
+	/* Out Buffer and In Buffer size */
+	int outbuffersz;
+	int inbuffersz;
+
 };
 
 /*  Initialise the socket. */

--- a/src/nn.h
+++ b/src/nn.h
@@ -335,6 +335,10 @@ NN_EXPORT  struct nn_cmsghdr *nn_cmsg_nxthdr_ (
 #define NN_PROTOCOL 13
 #define NN_IPV4ONLY 14
 #define NN_SOCKET_NAME 15
+#define NN_SEC_ATTR 16
+#define NN_OUTBUFSZ 17
+#define NN_INBUFSZ 18
+
 
 /*  Send/recv options.                                                        */
 #define NN_DONTWAIT 1

--- a/src/transports/ipc/aipc.c
+++ b/src/transports/ipc/aipc.c
@@ -81,6 +81,7 @@ int nn_aipc_isidle (struct nn_aipc *self)
 
 void nn_aipc_start (struct nn_aipc *self, struct nn_usock *listener)
 {
+	size_t sz;
     nn_assert_state (self, NN_AIPC_STATE_IDLE);
 
     /*  Take ownership of the listener socket. */
@@ -88,6 +89,14 @@ void nn_aipc_start (struct nn_aipc *self, struct nn_usock *listener)
     self->listener_owner.src = NN_AIPC_SRC_LISTENER;
     self->listener_owner.fsm = &self->fsm;
     nn_usock_swap_owner (listener, &self->listener_owner);
+
+#if defined NN_HAVE_WINDOWS
+	/* Get/Set security attribute pointer*/
+	nn_epbase_getopt (self->epbase, NN_SOL_SOCKET, NN_SEC_ATTR, &self->usock.sec_attr, &sz);
+
+	nn_epbase_getopt (self->epbase, NN_SOL_SOCKET, NN_OUTBUFSZ, &self->usock.outbuffersz, &sz);
+	nn_epbase_getopt (self->epbase, NN_SOL_SOCKET, NN_INBUFSZ, &self->usock.inbuffersz, &sz);
+#endif
 
     /*  Start the state machine. */
     nn_fsm_start (&self->fsm);

--- a/src/transports/ipc/aipc.c
+++ b/src/transports/ipc/aipc.c
@@ -81,7 +81,7 @@ int nn_aipc_isidle (struct nn_aipc *self)
 
 void nn_aipc_start (struct nn_aipc *self, struct nn_usock *listener)
 {
-	size_t sz;
+    size_t sz;
     nn_assert_state (self, NN_AIPC_STATE_IDLE);
 
     /*  Take ownership of the listener socket. */
@@ -91,11 +91,11 @@ void nn_aipc_start (struct nn_aipc *self, struct nn_usock *listener)
     nn_usock_swap_owner (listener, &self->listener_owner);
 
 #if defined NN_HAVE_WINDOWS
-	/* Get/Set security attribute pointer*/
-	nn_epbase_getopt (self->epbase, NN_SOL_SOCKET, NN_SEC_ATTR, &self->usock.sec_attr, &sz);
+    /* Get/Set security attribute pointer*/
+    nn_epbase_getopt (self->epbase, NN_SOL_SOCKET, NN_SEC_ATTR, &self->usock.sec_attr, &sz);
 
-	nn_epbase_getopt (self->epbase, NN_SOL_SOCKET, NN_OUTBUFSZ, &self->usock.outbuffersz, &sz);
-	nn_epbase_getopt (self->epbase, NN_SOL_SOCKET, NN_INBUFSZ, &self->usock.inbuffersz, &sz);
+    nn_epbase_getopt (self->epbase, NN_SOL_SOCKET, NN_OUTBUFSZ, &self->usock.outbuffersz, &sz);
+    nn_epbase_getopt (self->epbase, NN_SOL_SOCKET, NN_INBUFSZ, &self->usock.inbuffersz, &sz);
 #endif
 
     /*  Start the state machine. */

--- a/src/transports/ipc/cipc.c
+++ b/src/transports/ipc/cipc.c
@@ -416,6 +416,14 @@ static void nn_cipc_start_connecting (struct nn_cipc *self)
     ss.ss_family = AF_UNIX;
     strncpy (un->sun_path, addr, sizeof (un->sun_path));
 
+#if defined NN_HAVE_WINDOWS
+    /* Get/Set security attribute pointer*/
+    nn_epbase_getopt (&self->epbase, NN_SOL_SOCKET, NN_SEC_ATTR, &self->usock.sec_attr, &sz);
+
+    nn_epbase_getopt (&self->epbase, NN_SOL_SOCKET, NN_OUTBUFSZ, &self->usock.outbuffersz, &sz);
+    nn_epbase_getopt (&self->epbase, NN_SOL_SOCKET, NN_INBUFSZ, &self->usock.inbuffersz, &sz);
+#endif
+
     /*  Start connecting. */
     nn_usock_connect (&self->usock, (struct sockaddr*) &ss,
         sizeof (struct sockaddr_un));

--- a/tests/win_sec_attr.c
+++ b/tests/win_sec_attr.c
@@ -1,0 +1,96 @@
+/*
+    Copyright (c) 2012 Martin Sustrik  All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom
+    the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#include "../src/nn.h"
+#include "../src/pair.h"
+#include "../src/pubsub.h"
+#include "../src/ipc.h"
+
+#include "testutil.h"
+
+#include <AccCtrl.h>
+#include <Aclapi.h>
+
+/*  Windows only. Custom SECURITY_ATTRIBUTES on a socket. */
+
+#define SOCKET_ADDRESS "ipc://win_sec_attr.ipc"
+
+int main ()
+{
+    int sb;
+    int sc;
+    SECURITY_ATTRIBUTES sec;
+    BOOL ret;
+    SID SIDAuthUsers;
+    DWORD SIDSize;
+    EXPLICIT_ACCESS xa;
+    PACL pACL;
+    DWORD ret2;
+    int ret3;
+
+    sc = test_socket (AF_SP, NN_PAIR);
+    test_connect (sc, SOCKET_ADDRESS);
+
+    sb = test_socket (AF_SP, NN_PAIR);
+
+    memset (&sec, 0, sizeof(sec));
+    sec.lpSecurityDescriptor = (PSECURITY_DESCRIPTOR)malloc (SECURITY_DESCRIPTOR_MIN_LENGTH);
+    ret = InitializeSecurityDescriptor (sec.lpSecurityDescriptor, SECURITY_DESCRIPTOR_REVISION);
+    nn_assert (ret);
+
+    SIDSize = sizeof (SIDAuthUsers);
+    ret = CreateWellKnownSid (WinAuthenticatedUserSid, NULL, &SIDAuthUsers, &SIDSize);
+    nn_assert (ret);
+
+    xa.grfAccessPermissions = GENERIC_READ | GENERIC_WRITE;
+    xa.grfAccessMode = SET_ACCESS;
+    xa.grfInheritance = SUB_CONTAINERS_AND_OBJECTS_INHERIT;
+    xa.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+    xa.Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
+    xa.Trustee.ptstrName  = (LPSTR) &SIDAuthUsers;
+    ret2 = SetEntriesInAcl (1, &xa, NULL, &pACL);
+    nn_assert (ret2 == ERROR_SUCCESS);
+
+    ret = SetSecurityDescriptorDacl (sec.lpSecurityDescriptor, TRUE, pACL, FALSE);
+    nn_assert (ret);
+
+    sec.nLength = sizeof(sec);
+    sec.bInheritHandle = TRUE;
+
+    ret3 = nn_setsockopt (sb, NN_SOL_SOCKET, NN_SEC_ATTR, (void*)&sec, sizeof(SECURITY_ATTRIBUTES));
+    nn_assert (ret3 == 0);
+
+    test_bind (sb, SOCKET_ADDRESS);
+
+    nn_sleep (200);
+
+    test_send (sc, "0123456789012345678901234567890123456789");
+    test_recv (sb, "0123456789012345678901234567890123456789");
+
+    test_close (sc);
+    test_close (sb);
+
+    LocalFree (pACL);
+    free (sec.lpSecurityDescriptor);
+
+    return 0;
+}


### PR DESCRIPTION
This patch adds support for setting the security attributes when creating the sockets. We use this for IPC named pipes, where we have a priviledged service that needs communicating with processes in other sessions. Comes with a little demo / test.
