### PR TITLE
tweaks for build snags in HP-UX (aCC)

### DIFF
--- a/src/aio/usock_posix.inc
+++ b/src/aio/usock_posix.inc
@@ -1100,7 +1100,7 @@ static int nn_usock_recv_raw (struct nn_usock *self, void *buf, size_t *len)
     hdr.msg_controllen = sizeof (ctrl);
 #else
     *((int*) ctrl) = -1;
-    hdr.msg_accrights = ctrl;
+    hdr.msg_accrights = (caddr_t)ctrl;
     hdr.msg_accrightslen = sizeof (int);
 #endif
     nbytes = recvmsg (self->s, &hdr, 0);

--- a/src/core/sock.c
+++ b/src/core/sock.c
@@ -353,6 +353,7 @@ static int nn_sock_setopt_inner (struct nn_sock *self, int level,
     }
 
     nn_assert (0);
+    return -ENOPROTOOPT;
 }
 
 int nn_sock_getopt (struct nn_sock *self, int level, int option,
@@ -463,6 +464,7 @@ int nn_sock_getopt_inner (struct nn_sock *self, int level,
     }
 
     nn_assert (0);
+    return -ENOPROTOOPT;
 }
 
 int nn_sock_add_ep (struct nn_sock *self, struct nn_transport *transport,
@@ -550,7 +552,7 @@ int nn_sock_send (struct nn_sock *self, struct nn_msg *msg, int flags)
 
     /*  Compute the deadline for SNDTIMEO timer. */
     if (self->sndtimeo < 0) {
-        deadline = -1;
+        deadline = (uint64_t)-1;
         timeout = -1;
     }
     else {
@@ -628,7 +630,7 @@ int nn_sock_recv (struct nn_sock *self, struct nn_msg *msg, int flags)
 
     /*  Compute the deadline for RCVTIMEO timer. */
     if (self->rcvtimeo < 0) {
-        deadline = -1;
+        deadline = (uint64_t)-1;
         timeout = -1;
     }
     else {

--- a/src/devices/device.c
+++ b/src/devices/device.c
@@ -185,6 +185,7 @@ int nn_device_entry (struct nn_device_recipe *device, int s1, int s2,
 
     /*  This should never happen. */
     nn_assert (0);
+    return -1;
 }
 
 int nn_device_loopback (struct nn_device_recipe *device, int s)

--- a/src/devices/tcpmuxd.c
+++ b/src/devices/tcpmuxd.c
@@ -326,8 +326,8 @@ static int nn_tcpmuxd_send_fd (int s, int fd)
     struct iovec iov;
     char c = 0;
     struct msghdr msg;
-    char control [sizeof (struct cmsghdr) + 10];
 #if defined NN_HAVE_MSG_CONTROL
+    char control [sizeof (struct cmsghdr) + 10];
     struct cmsghdr *cmsg;
 #endif
 

--- a/src/protocols/pubsub/trie.c
+++ b/src/protocols/pubsub/trie.c
@@ -112,7 +112,7 @@ void nn_node_dump (struct nn_trie_node *self, int indent)
     }
 
     for (i = 0; i != children; ++i)
-        nn_node_dump (((struct nn_trie_node**) (self + 1)) [i], indent + 1);
+        nn_node_dump ( ((struct nn_trie_node **)(void *)(self + 1))[i], indent + 1);
 
     nn_node_indent (indent);
     printf ("===================\n");
@@ -173,7 +173,7 @@ struct nn_trie_node **nn_node_child (struct nn_trie_node *self, int index)
 {
     /*  Finds pointer to the n-th child of the node. */
 
-    return ((struct nn_trie_node**) (self + 1)) + index;
+    return ((struct nn_trie_node **)(void *)(self + 1)) + index;
 }
 
 struct nn_trie_node **nn_node_next (struct nn_trie_node *self, uint8_t c)

--- a/src/protocols/reqrep/req.c
+++ b/src/protocols/reqrep/req.c
@@ -268,7 +268,7 @@ int nn_req_recv (int s, nn_req_handle *hndl, void *buf, size_t len,
     int flags)
 {
     nn_assert (0);
-	return -1;
+    return -1;
 }
 
 

--- a/src/protocols/reqrep/req.c
+++ b/src/protocols/reqrep/req.c
@@ -236,6 +236,7 @@ int nn_req_send (int s, nn_req_handle hndl, const void *buf, size_t len,
     int flags)
 {
     nn_assert (0);
+    return -1;
 }
 
 int nn_req_csend (struct nn_sockbase *self, struct nn_msg *msg)
@@ -267,6 +268,7 @@ int nn_req_recv (int s, nn_req_handle *hndl, void *buf, size_t len,
     int flags)
 {
     nn_assert (0);
+	return -1;
 }
 
 

--- a/src/transports/ws/sws.c
+++ b/src/transports/ws/sws.c
@@ -154,10 +154,10 @@ void nn_sws_init (struct nn_sws *self, int src,
         NN_SWS_UTF8_MAX_CODEPOINT_LEN);
     self->utf8_code_pt_fragment_len = 0;
 
-    self->pings_sent;
+    /*self->pings_sent;
     self->pongs_sent;
     self->pings_received;
-    self->pongs_received;
+    self->pongs_received;*/
 
     nn_fsm_event_init (&self->done);
 }
@@ -317,6 +317,7 @@ static int nn_utf8_code_point (const uint8_t *buffer, size_t len)
 
     /*  Algorithm error; a case above should have been satisfied. */
     nn_assert (0);
+    return NN_SWS_UTF8_INVALID;
 }
 
 static void nn_sws_mask_payload (uint8_t *payload, size_t payload_len,

--- a/src/transports/ws/ws_handshake.c
+++ b/src/transports/ws/ws_handshake.c
@@ -1216,7 +1216,7 @@ static void nn_ws_handshake_client_request (struct nn_ws_handshake *self)
     /*  Pre-calculated expected Accept Key value as per
         RFC 6455 section 4.2.2.5.4 (version December 2011). */
     rc = nn_ws_handshake_hash_key ((const uint8_t *)encoded_key, encoded_key_len,
-			(uint8_t *)self->expected_accept_key, sizeof (self->expected_accept_key));
+            (uint8_t *)self->expected_accept_key, sizeof (self->expected_accept_key));
 
     nn_assert (rc == NN_WS_HANDSHAKE_ACCEPT_KEY_LEN);
 
@@ -1265,7 +1265,7 @@ static void nn_ws_handshake_server_reply (struct nn_ws_handshake *self)
         /*  Upgrade connection as per RFC 6455 section 4.2.2. */
         
         rc = nn_ws_handshake_hash_key (self->key, self->key_len,
-				(uint8_t *)accept_key, sizeof (accept_key));
+                (uint8_t *)accept_key, sizeof (accept_key));
 
         nn_assert (strlen (accept_key) == NN_WS_HANDSHAKE_ACCEPT_KEY_LEN);
 
@@ -1349,7 +1349,7 @@ static int nn_ws_handshake_hash_key (const uint8_t *key, size_t key_len,
         nn_sha1_hashbyte (&hash, NN_WS_HANDSHAKE_MAGIC_GUID [i]);
 
     rc = nn_base64_encode (nn_sha1_result (&hash),
-			sizeof (hash.state), (char *)hashed, hashed_len);
+            sizeof (hash.state), (char *)hashed, hashed_len);
 
     return rc;
 }

--- a/tests/zerocopy.c
+++ b/tests/zerocopy.c
@@ -38,9 +38,9 @@ void test_allocmsg_reqrep ()
     struct nn_msghdr hdr;
 
     /*  Try to create an oversized message. */
-    p = nn_allocmsg (-1, 0);
+    p = nn_allocmsg ((unsigned int)-1, 0);
     nn_assert (!p && nn_errno () == ENOMEM);
-    p = nn_allocmsg (-1000, 0);
+    p = nn_allocmsg ((unsigned int)-1000, 0);
     nn_assert (!p && nn_errno () == ENOMEM);
 
     /*  Try to create a message of unknown type. */
@@ -98,7 +98,7 @@ void test_reallocmsg_reqrep ()
     /*  Create message, make sure we handle overflow. */
     p = nn_allocmsg (100, 0);
     nn_assert (p);
-    p2 = nn_reallocmsg (p, -1000);
+    p2 = nn_reallocmsg (p, (unsigned int)-1000);
     errno_assert (nn_errno () == ENOMEM);
     nn_assert (p2 == NULL);
 

--- a/tools/nanocat.c
+++ b/tools/nanocat.c
@@ -575,7 +575,9 @@ void nn_rw_loop (nn_options_t *options, int sock)
         }
     }
 
+    /* unreachable
     nn_clock_term(&clock);
+    */
 }
 
 void nn_resp_loop (nn_options_t *options, int sock)

--- a/tools/options.c
+++ b/tools/options.c
@@ -67,6 +67,7 @@ static int nn_has_arg (struct nn_option *opt)
             return 1;
     }
     nn_assert (0);
+    return -1;
 }
 
 static void nn_print_usage (struct nn_parse_context *ctx, FILE *stream)


### PR DESCRIPTION
It's mostly (hopefully) harmless casts and missing (unreachable) returns.

But, in `protocols/pubsub/trie.c`, `nn_node_child()` and bottom of `nn_node_dump()`, there's an alignment problem that I guess could be very bad:
```
"src/protocols/pubsub/trie.c", line 115: warning #4232-D: conversion from
          "struct nn_trie_node *" to a more strictly aligned type
          "struct nn_trie_node **" may cause misaligned access
          nn_node_dump (((struct nn_trie_node**) (self + 1)) [i], indent + 1);
                         ^
"src/protocols/pubsub/trie.c", line 176: warning #4232-D: conversion from
          "struct nn_trie_node *" to a more strictly aligned type
          "struct nn_trie_node **" may cause misaligned access
      return ((struct nn_trie_node**) (self + 1)) + index;
              ^
```
As I'm not sure how to fix this, I inserted a `(void *)` cast which shut the warning up, but the problem still exists, of course.

Also, the test cases `ipc_shutdown` and `tcp_shutdown` fail with "Broken pipe" signal.
If I understand the test code correctly this is kind of its purpose, i.e. sending on a socket that's shutting down?
Is it just a question of capturing the signal so the test doesn't fail, perchance? Any idea how I might go about that?