### PR TITLE
Fixed a SEGV error when using nanomsg on CentOS5/RHEL5

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,7 +40,8 @@ nninclude_HEADERS = \
     src/reqrep.h \
     src/pipeline.h \
     src/survey.h \
-    src/bus.h
+    src/bus.h\
+    src/tcpmux.h
 
 lib_LTLIBRARIES = libnanomsg.la
 

--- a/configure.ac
+++ b/configure.ac
@@ -310,10 +310,20 @@ AC_CHECK_FUNCS([accept4], [
     AC_DEFINE([NN_HAVE_ACCEPT4])
     CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE"
 ])
+
 AC_SEARCH_LIBS([getaddrinfo_a], [anl], [
     AC_DEFINE([NN_HAVE_GETADDRINFO_A])
     CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE"
 ])
+# Allow the use of getaddrinfo_a to be disabled.
+AC_ARG_ENABLE([getaddrinfo_a],
+    AS_HELP_STRING([--enable-getaddrinfo_a], [Use getaddrinfo_a if available [default=yes]])
+)
+AS_IF([test x"$enable_getaddrinfo_a" == "xno"], [
+    AC_DEFINE([NN_DISABLE_GETADDRINFO_A])
+])
+
+
 AC_SEARCH_LIBS([socketpair], [], [
     AC_DEFINE([NN_HAVE_SOCKETPAIR])
 ])

--- a/src/transports/utils/dns.c
+++ b/src/transports/utils/dns.c
@@ -88,7 +88,7 @@ int nn_dns_check_hostname (const char *name, size_t namelen)
     }
 }
 
-#if defined NN_HAVE_GETADDRINFO_A
+#if defined NN_HAVE_GETADDRINFO_A && !defined NN_DISABLE_GETADDRINFO_A
 #include "dns_getaddrinfo_a.inc"
 #else
 #include "dns_getaddrinfo.inc"

--- a/src/transports/utils/dns.h
+++ b/src/transports/utils/dns.h
@@ -35,7 +35,7 @@ int nn_dns_check_hostname (const char *name, size_t namelen);
 #define NN_DNS_DONE 1
 #define NN_DNS_STOPPED 2
 
-#if defined NN_HAVE_GETADDRINFO_A
+#if defined NN_HAVE_GETADDRINFO_A && !defined NN_DISABLE_GETADDRINFO_A
 #include "dns_getaddrinfo_a.h"
 #else
 #include "dns_getaddrinfo.h"


### PR DESCRIPTION
Older versions of glibc have a problem with getaddrinfo_a and the size of stack it allocates for the thread that performs the lookup. This causes a process built with nanomsg to crash when it needs to do a DNS lookup.

This fixes this issue by allowing the use of getaddrinfo_a to be disabled at configuration time by specifying '--disable-getaddrinfo_a'.