### PR TITLE
Fix a leak caused by not freeing the result of getaddrinfo_a().

### DIFF
--- a/src/transports/utils/dns_getaddrinfo_a.inc
+++ b/src/transports/utils/dns_getaddrinfo_a.inc
@@ -151,6 +151,7 @@ static void nn_dns_notify (union sigval sval)
         memcpy (&self->result->addr, self->gcb.ar_result->ai_addr,
             self->gcb.ar_result->ai_addrlen);
         self->result->addrlen = (size_t) self->gcb.ar_result->ai_addrlen;
+        freeaddrinfo(self->gcb.ar_result);
         nn_fsm_action (&self->fsm, NN_DNS_ACTION_DONE);
     }
     nn_ctx_leave (self->fsm.ctx);


### PR DESCRIPTION
A small block is leaked for every call of nn_connect() which can be massive on the client side.