### PR TITLE
Deferred start of the global FSM to avoid race condition with line 1267 ...

### DIFF
--- a/src/core/global.c
+++ b/src/core/global.c
@@ -291,7 +291,6 @@ static void nn_global_init (void)
 
     nn_ctx_init (&self.ctx, nn_global_getpool (), NULL);
     nn_timer_init (&self.stat_timer, NN_GLOBAL_SRC_STAT_TIMER, &self.fsm);
-    nn_fsm_start (&self.fsm);
 
     /*   Initializing special sockets.  */
     addr = getenv ("NN_STATISTICS_SOCKET");
@@ -333,6 +332,8 @@ static void nn_global_init (void)
         errno_assert (rc == 0);
         self.hostname[63] = '\0';
     }
+
+    nn_fsm_start(&self.fsm);
 }
 
 static void nn_global_term (void)


### PR DESCRIPTION
...in FSM handler. The problem was that line 1267, `global->statistics_socket` would not have been initialized properly by the lines 297-305 block, causing the 10sec timer to start in the global FSM. 

@djc can you reproduce, and do you agree with this change? Delaying the FSM start was the obvious/simple fix, but you may have a better idea (feel free to refactor in this branch prior to merging) -- thanks!