### PR TITLE
Change from malloc to calloc

### DIFF
--- a/src/utils/alloc.c
+++ b/src/utils/alloc.c
@@ -56,7 +56,7 @@ void *nn_alloc_ (size_t size, const char *name)
 {
     uint8_t *chunk;
 
-    chunk = calloc (sizeof (struct nn_alloc_hdr) + size, sizeof(size_t));
+    chunk = calloc (sizeof (struct nn_alloc_hdr) + size, sizeof(uint8_t));
     if (!chunk)
         return NULL;
 
@@ -130,7 +130,7 @@ void nn_alloc_term (void)
 
 void *nn_alloc_ (size_t size)
 {
-    return calloc (size, sizeof(size_t));
+    return calloc (size, sizeof(uint8_t));
 }
 
 void *nn_realloc (void *ptr, size_t size)

--- a/src/utils/alloc.c
+++ b/src/utils/alloc.c
@@ -56,7 +56,7 @@ void *nn_alloc_ (size_t size, const char *name)
 {
     uint8_t *chunk;
 
-    chunk = malloc (sizeof (struct nn_alloc_hdr) + size);
+    chunk = calloc (sizeof (struct nn_alloc_hdr) + size, sizeof(size_t));
     if (!chunk)
         return NULL;
 
@@ -101,7 +101,6 @@ void *nn_realloc (void *ptr, size_t size)
 void nn_free (void *ptr)
 {
     struct nn_alloc_hdr *chunk;
-    
     if (!ptr)
         return;
     chunk = ((struct nn_alloc_hdr*) ptr) - 1;
@@ -131,7 +130,7 @@ void nn_alloc_term (void)
 
 void *nn_alloc_ (size_t size)
 {
-    return malloc (size);
+    return calloc (size, sizeof(size_t));
 }
 
 void *nn_realloc (void *ptr, size_t size)
@@ -145,4 +144,3 @@ void nn_free (void *ptr)
 }
 
 #endif
-


### PR DESCRIPTION
changes to make sure that the alloced memory block is zero filled,
takes a little more time but ALWAYS worth it.. to keep garbage out of
the memory block.

These changes are submitted under the MIT License 