### PR TITLE
replace asserts with return -1,

### DIFF
--- a/src/devices/tcpmuxd.c
+++ b/src/devices/tcpmuxd.c
@@ -91,19 +91,20 @@ int nn_tcpmuxd (int port)
 
     /*  Start listening on the specified TCP port. */
     tcp_listener = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    errno_assert (tcp_listener >= 0);
+    if (tcp_listener < 0) { return -1; }
     opt = 1;
     rc = setsockopt (tcp_listener, SOL_SOCKET, SO_REUSEADDR, &opt,
         sizeof (opt));
-    errno_assert (rc == 0);
+    if (rc != 0) { return -1; }
     memset (&tcp_addr, 0, sizeof (tcp_addr));
     tcp_addr.sin_family = AF_INET;
     tcp_addr.sin_port = htons (port);
     tcp_addr.sin_addr.s_addr = INADDR_ANY;
     rc = bind (tcp_listener, (struct sockaddr*) &tcp_addr, sizeof (tcp_addr));
-    errno_assert (rc == 0);
+    if (rc != 0) { return -1; }
     rc = listen (tcp_listener, 100);
-    errno_assert (rc == 0);
+    if (rc != 0) { return -1; }
+
 
     /*  Start listening for incoming IPC connections. */
     ipc_addr.sun_family = AF_UNIX;
@@ -113,9 +114,9 @@ int nn_tcpmuxd (int port)
     ipc_listener = socket (AF_UNIX, SOCK_STREAM, 0);
     errno_assert (ipc_listener >= 0);
     rc = bind (ipc_listener, (struct sockaddr*) &ipc_addr, sizeof (ipc_addr));
-    errno_assert (rc == 0);
+    if (rc != 0) { return -1; }
     rc = listen (ipc_listener, 100);
-    errno_assert (rc == 0);
+    if (rc != 0) { return -1; }
 
     /*  Allocate a context for the daemon. */
     ctx = nn_alloc (sizeof (struct nn_tcpmuxd_ctx), "tcpmuxd context");

--- a/src/devices/tcpmuxd.c
+++ b/src/devices/tcpmuxd.c
@@ -90,6 +90,7 @@ int nn_tcpmuxd (int port)
     struct nn_tcpmuxd_ctx *ctx;
 
     /*  Start listening on the specified TCP port. */
+    errno = 0;
     tcp_listener = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (tcp_listener < 0) { return -1; }
     opt = 1;
@@ -105,14 +106,16 @@ int nn_tcpmuxd (int port)
     rc = listen (tcp_listener, 100);
     if (rc != 0) { return -1; }
 
-
     /*  Start listening for incoming IPC connections. */
     ipc_addr.sun_family = AF_UNIX;
     snprintf (ipc_addr.sun_path, sizeof (ipc_addr.sun_path),
         "/tmp/tcpmux-%d.ipc", (int) port);
     unlink (ipc_addr.sun_path);
+    errno = 0;
     ipc_listener = socket (AF_UNIX, SOCK_STREAM, 0);
-    errno_assert (ipc_listener >= 0);
+    if (ipc_listener < 0) {
+      return -1;
+    }
     rc = bind (ipc_listener, (struct sockaddr*) &ipc_addr, sizeof (ipc_addr));
     if (rc != 0) { return -1; }
     rc = listen (ipc_listener, 100);


### PR DESCRIPTION
so nn_tcpmuxd() can be sanely called in a library. For example, in my R bindings, I would like to use nn_tcpmuxd(), and I can't have a failed call crashing the entire R application [https://github.com/glycerine/nanomsgardvark/commit/2b6af3a74b83b3f4be3a017b86027359e59a047d].