### PR TITLE
Add PicoLisp-Nanomsg FFI bindings

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -105,6 +105,9 @@
 <h4>PHP</h4>
 <p><a href="https://github.com/mkoppanen/php-nano">https://github.com/mkoppanen/php-nano</a></p>
 
+<h4>PicoLisp</h4>
+<p><a href="https://github.com/aw/picolisp-nanomsg">https://github.com/aw/picolisp-nanomsg</a> FFI bindings</p>
+
 <h4>Python</h4>
 <p><a href="https://github.com/tonysimpson/nanomsg-python">https://github.com/tonysimpson/nanomsg-python</a> (recommended)</p>
 <p><a href="https://github.com/sdiehl/pynanomsg">https://github.com/sdiehl/pynanomsg</a></p>


### PR DESCRIPTION
Hi,

I created the [FFI bindings](https://github.com/aw/picolisp-nanomsg) for [PicoLisp](http://picolisp.com/) and updated the documentation.

All known protocols are supported :panda_face: Thanks!