### PR TITLE
Multiple buffer message receiving with nanomsg allocated buffers

### DIFF
--- a/src/core/global.c
+++ b/src/core/global.c
@@ -880,7 +880,7 @@ int nn_recvmsg (int s, struct nn_msghdr *msghdr, int flags)
     int rc;
     struct nn_msg msg;
     uint8_t *data;
-    size_t sz;
+    size_t sz, chunk_sz;
     int i;
     struct nn_iovec *iov;
     void *chunk;
@@ -918,21 +918,17 @@ int nn_recvmsg (int s, struct nn_msghdr *msghdr, int flags)
     else if (msghdr->msg_iovlen > 1 && msghdr->msg_iov [0].iov_len == NN_MSG) {
         chunk = nn_chunkref_getchunk (&msg.body);
         
+        sz = 0;
         for (i = 0; i != msghdr->msg_iovlen; ++i) {
             iov = &msghdr->msg_iov [i];
             
             iov->iov_base = chunk;
             
-            sz = strlen ((const char*) chunk) + sizeof (uint8_t);
-            chunk += sz;
+            chunk_sz = strlen ((const char*) chunk) + sizeof (uint8_t);
+            chunk += chunk_sz;
             
-            iov->iov_len = sz;
-        }
-        
-        sz = 0;
-        for (i = 0; i != msghdr->msg_iovlen; ++i) {
-            iov = &msghdr->msg_iov [i];
-            sz += iov->iov_len;
+            iov->iov_len = chunk_sz;
+            sz += chunk_sz;
         }
     }
     else {

--- a/src/nn.h
+++ b/src/nn.h
@@ -266,6 +266,7 @@ NN_EXPORT int nn_freemsg (void *msg);
 
 struct nn_iovec {
     void *iov_base;
+    void *iov_base_len;
     size_t iov_len;
 };
 

--- a/src/utils/chunkref.c
+++ b/src/utils/chunkref.c
@@ -45,6 +45,7 @@ void nn_chunkref_init (struct nn_chunkref *self, size_t size)
     struct nn_chunkref_chunk *ch;
 
     if (size < NN_CHUNKREF_MAX) {
+        memset (self, 0, sizeof (*self));
         self->u.ref [0] = (uint8_t) size;
         return;
     }

--- a/tests/inproc.c
+++ b/tests/inproc.c
@@ -176,15 +176,18 @@ int main ()
     test_connect (sc, SOCKET_ADDRESS);
 
     void *send_buffer_1 = nn_allocmsg (5, 0),
-        * send_buffer_2 = nn_allocmsg (4, 0);
+         *send_buffer_2 = nn_allocmsg (4, 0);
     strcpy (send_buffer_1, "ABCD");
+    size_t sz1 = 5, sz2 = 4;
     strcpy (send_buffer_2, "XYZ");
     struct nn_msghdr send_msg;
     struct nn_iovec send_iovecs[2];
     send_iovecs [0].iov_base = &send_buffer_1;
     send_iovecs [0].iov_len = NN_MSG;
+    send_iovecs [0].iov_base_len = &sz1;
     send_iovecs [1].iov_base = &send_buffer_2;
     send_iovecs [1].iov_len = NN_MSG;
+    send_iovecs [1].iov_base_len = &sz2;
     memset (&send_msg, 9, sizeof (send_msg));
     send_msg.msg_iov = send_iovecs;
     send_msg.msg_iovlen = 2;

--- a/tests/inproc.c
+++ b/tests/inproc.c
@@ -168,7 +168,8 @@ int main ()
     test_close (sc);
     test_close (sb);
 
-    /* Check whether SP message header is transferred correctly. */
+    /* Check whether a multiple null-terminated buffer message */
+    /* is received in the same number of buffers */
     sb = test_socket (AF_SP_RAW, NN_REP);
     test_bind (sb, SOCKET_ADDRESS);
     sc = test_socket (AF_SP, NN_REQ);


### PR DESCRIPTION
Sent multiple buffer messages should be received in the same number of buffers it was sent with when allowing nanomsg to allocate the buffers for them.