### PR TITLE
Allowed nn_sleep to be exported on Windows.

### DIFF
--- a/src/utils/sleep.c
+++ b/src/utils/sleep.c
@@ -20,6 +20,7 @@
     IN THE SOFTWARE.
 */
 
+#include "../nn.h"
 #include "sleep.h"
 #include "err.h"
 

--- a/src/utils/sleep.h
+++ b/src/utils/sleep.h
@@ -25,6 +25,6 @@
 
 /*  Platform independent implementation of sleeping. */
 
-void nn_sleep (int milliseconds);
+NN_EXPORT void nn_sleep (int milliseconds);
 
 #endif


### PR DESCRIPTION
At present, the `nanomsg.dll` built on Windows does not export the `nn_sleep` API, even though there is an implementation on Windows. This appears to be just because the symbol isn't marked for export using `NN_EXPORT`.