### PR TITLE
fixes #439 exposing nn_sleep() was a mistake

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -141,6 +141,7 @@ NANOMSG_UTILS = \
     src/utils/random.c \
     src/utils/sem.h \
     src/utils/sem.c \
+    src/utils/sleep.h \
     src/utils/sleep.c \
     src/utils/stopwatch.h \
     src/utils/stopwatch.c \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ set (NN_SOURCES
     utils/random.c
     utils/sem.h
     utils/sem.c
+    utils/sleep.h
     utils/sleep.c
     utils/thread.h
     utils/thread.c

--- a/src/core/poll.c
+++ b/src/core/poll.c
@@ -26,6 +26,7 @@
 
 #include "../utils/win.h"
 #include "../utils/fast.h"
+#include "../utils/sleep.h"
 #include "../utils/err.h"
 
 int nn_poll (struct nn_pollfd *fds, int nfds, int timeout)

--- a/src/nn.h
+++ b/src/nn.h
@@ -357,7 +357,6 @@ NN_EXPORT int nn_send (int s, const void *buf, size_t len, int flags);
 NN_EXPORT int nn_recv (int s, void *buf, size_t len, int flags);
 NN_EXPORT int nn_sendmsg (int s, const struct nn_msghdr *msghdr, int flags);
 NN_EXPORT int nn_recvmsg (int s, struct nn_msghdr *msghdr, int flags);
-NN_EXPORT void nn_sleep (int milliseconds);
 
 /******************************************************************************/
 /*  Socket mutliplexing support.                                              */

--- a/src/utils/sleep.h
+++ b/src/utils/sleep.h
@@ -20,31 +20,11 @@
     IN THE SOFTWARE.
 */
 
-#include "sleep.h"
-#include "err.h"
+#ifndef NN_SLEEP_INCLUDED
+#define NN_SLEEP_INCLUDED
 
-#ifdef NN_HAVE_WINDOWS
+/*  Platform independent implementation of sleeping. */
 
-#include "win.h"
-
-void nn_sleep (int milliseconds)
-{
-    Sleep (milliseconds);
-}
-
-#else
-
-#include <time.h>
-
-void nn_sleep (int milliseconds)
-{
-    int rc;
-    struct timespec ts;
-
-    ts.tv_sec = milliseconds / 1000;
-    ts.tv_nsec = milliseconds % 1000 * 1000000;
-    rc = nanosleep (&ts, NULL);
-    errno_assert (rc == 0);    
-}
+void nn_sleep (int milliseconds);
 
 #endif

--- a/tools/tcpmuxd.c
+++ b/tools/tcpmuxd.c
@@ -23,6 +23,7 @@
 #include "../src/nn.h"
 
 #include "../src/utils/err.h"
+#include "../src/utils/sleep.h"
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Revert "fixes #437 inconsistent DLL linkage for nn_sleep"
This reverts commit 3d978156c04bd75052deaa1726f2b4b5bccc989c.

Revert "Allowed nn_sleep to be exported on Windows."
This reverts commit e3588bc987f60fa841c153df89a70c7a3f1eb02c.