### PR TITLE
fixes #441 Add Travis CI badge for automated builds on linux

### DIFF
--- a/README
+++ b/README
@@ -7,6 +7,10 @@ applications communicate to form a single distributed application.
 
 For more info check the web site: http://nanomsg.org
 
+Build Status
+------------
+Linux (clang and gcc): [![Linux Status](https://travis-ci.org/nanomsg/nanomsg.svg?branch=master)](https://travis-ci.org/nanomsg/nanomsg)
+
 Build it
 --------
 


### PR DESCRIPTION
Feel free to copy/paste just the link to the top of the readme if  "Build Status" feels noisy; also, looked for AppVeyor build, but it looks like it's not public yet. @gdamore, I'll do what I can to help ease your burden on Windows, since that's one important platform for us, and since it's not your favorite :-)