### PR TITLE
Address issue #446

### DIFF
--- a/src/utils/efd_win.inc
+++ b/src/utils/efd_win.inc
@@ -56,15 +56,16 @@ int nn_efd_init (struct nn_efd *self)
 
     /*  This function has to be enclosed in a system-wide critical section
         so that two instances of the library don't accidentally create an efd
-        crossing the process boundary. 
-        CAUTION: This critical section has machine-wide scope. Thus, it must
-        be properly exited even before crashing the process by an assertion. */
-    sync = CreateEvent (&sa, FALSE, TRUE, "Global\\nanomsg-port-sync");
+        crossing the process boundary. */
+    sync = CreateMutex (&sa, FALSE, "Global\\nanomsg-port-sync");
     win_assert (sync != NULL);
 
     /*  Enter the critical section. */
     dwrc = WaitForSingleObject (sync, INFINITE);
-    nn_assert (dwrc == WAIT_OBJECT_0);
+    /* WAIT_OBJECT_0 indicates we have acquired the mutex
+       WAIT_ABANDONED indicates we have acquired the mutex, but that the
+       thread that owned the mutex last exited without releasing it first. */
+    nn_assert (dwrc == WAIT_OBJECT_0 || dwrc == WAIT_ABANDONED);
 
     /*  Unfortunately, on Windows the only way to send signal to a file
         descriptor (SOCKET) is to create a full-blown TCP connecting on top of
@@ -166,7 +167,7 @@ int nn_efd_init (struct nn_efd *self)
         goto wsafail;
 
     /*  Leave the critical section. */
-    brc = SetEvent (sync);
+    brc = ReleaseMutex (sync);
     win_assert (brc != 0);
     brc = CloseHandle (sync);
     win_assert (brc != 0);
@@ -184,7 +185,7 @@ int nn_efd_init (struct nn_efd *self)
 wsafail:
     rc = nn_err_wsa_to_posix (WSAGetLastError ());
 wsafail2:
-    brc = SetEvent (sync);
+    brc = ReleaseMutex (sync);
     win_assert (brc != 0);
     brc = CloseHandle (sync);
     win_assert (brc != 0);


### PR DESCRIPTION
This addresses issue #446.

Use a global mutex instead of a global event to protect the file descriptor creation on Windows.
An acquired mutex will be released when the thread that owns it exits without releasing the mutex explicitly, for example when a process is terminated.
The caveat is that any other process waiting for the mutex will get WAIT_ABANDONED instead of WAIT_OBJECT_0 returned from WaitForSingleObject. However, the mutex will be acquired by the previously waiting process. This is documented here near the remarks on WAIT_ABANDONED return value: https://msdn.microsoft.com/en-us/library/windows/desktop/ms687032

I tested this change by running the unit tests.
I further tested it by running "nanocat --req --bind tcp://127.0.0.1:8000 --data abcd -Q" instrumented to delay while the mutex was held. I terminated the one that had acquired the mutex and observed the other process continue seeing the WAIT_ABANDONED return code.