### PR TITLE
fix warning and update .gitignore for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ CMakeFiles
 .pydevproject
 *.sdf
 *.opensdf
+CMakeCache.txt
+*.cmake
+nanomsg.sln

--- a/src/transports/ws/sws.c
+++ b/src/transports/ws/sws.c
@@ -801,7 +801,7 @@ static int nn_sws_fail_conn (struct nn_sws *self, int code, char *reason)
     self->fail_msg [0] = NN_SWS_FRAME_BITMASK_FIN | NN_WS_OPCODE_CLOSE;
 
     /*  Size of the payload, which is the status code plus the reason. */
-    self->fail_msg [1] = payload_len;
+    self->fail_msg [1] = (char)payload_len;
 
     self->fail_msg_len = NN_SWS_FRAME_SIZE_INITIAL;
 

--- a/src/transports/ws/sws.c
+++ b/src/transports/ws/sws.c
@@ -801,7 +801,7 @@ static int nn_sws_fail_conn (struct nn_sws *self, int code, char *reason)
     self->fail_msg [0] = NN_SWS_FRAME_BITMASK_FIN | NN_WS_OPCODE_CLOSE;
 
     /*  Size of the payload, which is the status code plus the reason. */
-    self->fail_msg [1] = (char)payload_len;
+    self->fail_msg [1] = (uint8_t)payload_len;
 
     self->fail_msg_len = NN_SWS_FRAME_SIZE_INITIAL;
 

--- a/src/transports/ws/sws.h
+++ b/src/transports/ws/sws.h
@@ -152,7 +152,7 @@ struct nn_sws {
     uint8_t inmsg_control [NN_SWS_PAYLOAD_MAX_LENGTH];
 
     /*  Reason this connection is closing to send as closing handshake. */
-    char fail_msg [NN_SWS_PAYLOAD_MAX_LENGTH];
+    uint8_t fail_msg [NN_SWS_PAYLOAD_MAX_LENGTH];
     size_t fail_msg_len;
 
     /*  State of the outbound state machine. */


### PR DESCRIPTION
This is two small changes to make building for windows cleaner.