### PR TITLE
actually update status in nn_recvmsg

### DIFF
--- a/src/core/global.c
+++ b/src/core/global.c
@@ -955,6 +955,10 @@ int nn_recvmsg (int s, struct nn_msghdr *msghdr, int flags)
 
     nn_msg_term (&msg);
 
+    /*  Adjust the statistics. */
+    nn_sock_stat_increment (self.socks [s], NN_STAT_MESSAGES_RECEIVED, 1);
+    nn_sock_stat_increment (self.socks [s], NN_STAT_BYTES_RECEIVED, sz);
+
     return (int) sz;
 }
 


### PR DESCRIPTION
I don't see calls to nn_sock_stat_increment() for these counters anywhere else in the code base.

This pull request does what it says on the tin. I haven't checked if any of the other stats aren't getting set. I don't see any tests for stats code.

I can't remember if I need any sort of sign-off for patches. I release copyright to the project maintainers.