### PR TITLE
Fixes #463 crash when closing TCP socket

### DIFF
--- a/src/transports/tcp/btcp.c
+++ b/src/transports/tcp/btcp.c
@@ -238,7 +238,8 @@ static void nn_btcp_shutdown (struct nn_fsm *self, int src, int type,
         btcp->state = NN_BTCP_STATE_STOPPING_USOCK;
     }
     if (nn_slow (btcp->state == NN_BTCP_STATE_STOPPING_USOCK)) {
-       if (!nn_usock_isidle (&btcp->usock))
+       if (!nn_usock_isidle (&btcp->usock) ||
+             !nn_backoff_isidle (&btcp->retry))
             return;
         for (it = nn_list_begin (&btcp->atcps);
               it != nn_list_end (&btcp->atcps);

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -179,6 +179,23 @@ int main ()
     test_close (sc);
     test_close (s1);
 
+    /*  Test closing a socket that is waiting to bind. */
+    sb = test_socket (AF_SP, NN_PAIR);
+    test_bind (sb, SOCKET_ADDRESS);
+    nn_sleep (100);
+    s1 = test_socket (AF_SP, NN_PAIR);
+    test_bind (s1, SOCKET_ADDRESS);
+    sc = test_socket (AF_SP, NN_PAIR);
+    test_connect (sc, SOCKET_ADDRESS);
+    nn_sleep (100);
+    test_send (sb, "ABC");
+    test_recv (sc, "ABC");
+    test_close (s1);
+    test_send (sb, "ABC");
+    test_recv (sc, "ABC");
+    test_close (sb);
+    test_close (sc);
+
     /*  Test NN_RCVMAXSIZE limit */
     sb = test_socket (AF_SP, NN_PAIR);
     test_bind (sb, SOCKET_ADDRESS);
@@ -210,4 +227,3 @@ int main ()
 
     return 0;
 }
-


### PR DESCRIPTION
This is the bug fix from pull request #410 without the new nn_geterror feature and with a unit test that doesn't depend on nn_geterror