### PR TITLE
Assertion or Access Violation when calling nn_close while nn_recv blocks in separate thread

### DIFF
--- a/src/utils/err.c
+++ b/src/utils/err.c
@@ -160,6 +160,8 @@ int nn_err_wsa_to_posix (int wsaerr)
         return ECONNABORTED;
     case WSAECONNRESET:
         return ECONNRESET;
+    case WSAENOTSOCK:
+        return ENOTSOCK;
     case ERROR_BROKEN_PIPE:
         return ECONNRESET;
     case WSAESOCKTNOSUPPORT:


### PR DESCRIPTION
This pull request demonstrates and partially addresses another type of multithreading problem during TCP Shutdown on Windows.

It is split into two commits on purpose:

1) the first commit demonstrates the current issue in the form of a test -- the assertion failure in `efd.c`
2) the second commit fixes this issue by giving Windows platforms the same semantics as *NIX platforms, as shown above in `efd.c`

**However** -- this patch turns a guaranteed failure (old line 70 of `efd.c`) into a race condition within `sock.c`.

To best demonstrate this race condition, increase `TEST3_LOOPS ` in line 41 of `tcp_shutdown.c` test to be 10 or 100 iterations.

The current value of 1 iteration makes a lower likelihood of the race condition showing up, but it certainly still can manifest.