### PR TITLE
fixes #506 interface/address issue prevents bind/connect

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
 # Copyright (c) 2013 Luca Barbato
 # Copyright (c) 2013 GoPivotal, Inc.  All rights reserved.
+# Copyright 2015 Garrett D'Amore <garrett@damore.org>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"),
@@ -295,14 +296,6 @@ AC_CHECK_FUNCS([poll], [AC_DEFINE([NN_HAVE_POLL])])
 AC_CHECK_FUNCS([epoll_create], [AC_DEFINE([NN_USE_EPOLL])], [
     AC_CHECK_FUNCS([kqueue], [AC_DEFINE([NN_USE_KQUEUE])], [
         AC_DEFINE([NN_USE_POLL])
-    ])
-])
-
-AC_CHECK_FUNCS([getifaddrs], [AC_DEFINE([NN_USE_IFADDRS])], [
-    AC_EGREP_HEADER([SIOCGIFADDR], [sys/ioctl.h], [
-        AC_DEFINE([NN_USE_SIOCGIFADDR])
-    ], [
-        AC_DEFINE([NN_USE_LITERAL_IFADDR])
     ])
 ])
 

--- a/doc/nn_bind.txt
+++ b/doc/nn_bind.txt
@@ -70,7 +70,7 @@ EXAMPLE
 ----
 s = nn_socket (AF_SP, NN_PUB);
 eid1 = nn_bind (s, "inproc://test");
-eid2 = nn_bind (s, "tcp://eth0:5560");
+eid2 = nn_bind (s, "tcp://127.0.0.1:5560");
 ----
 
 

--- a/doc/nn_device.txt
+++ b/doc/nn_device.txt
@@ -47,9 +47,9 @@ EXAMPLE
 
 ----
 int s1 = nn_socket (AF_SP_RAW, NN_REQ);
-nn_bind (s1, "tcp://eth0:5555");
+nn_bind (s1, "tcp://127.0.0.1:5555");
 int s2 = nn_socket (AF_SP_RAW, NN_REP);
-nn_bind (s2, "tcp://eth0:5556");
+nn_bind (s2, "tcp://127.0.0.1:5556");
 nn_device (s1, s2);
 ----
 

--- a/doc/nn_tcp.txt
+++ b/doc/nn_tcp.txt
@@ -27,7 +27,6 @@ used. Port is the TCP port number to use. Interface is one of the following
 *  Asterisk character (*) meaning all local network interfaces.
 *  IPv4 address of a local network interface in numeric form (192.168.0.111).
 *  IPv6 address of a local network interface in numeric form (::1).
-*  Interface name, as defined by operating system.
 
 When connecting a TCP socket address of the form tcp://interface;address:port
 should be used. Port is the TCP port number to use. Interface is optional and
@@ -37,7 +36,6 @@ an appropriate interface itself. If specified it can be one of the following
 
 *  IPv4 address of a local network interface in numeric form (192.168.0.111).
 *  IPv6 address of a local network interface in numeric form (::1).
-*  Interface name, as defined by operating system (eth0).
 
 Finally, address specifies the remote address to connect to. It can be one of
 the following (optionally placed within square brackets):

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -292,7 +292,6 @@ endif ()
 add_library (nanomsg SHARED ${NN_SOURCES})
 
 add_definitions (-DNN_EXPORTS)
-add_definitions (-DNN_USE_LITERAL_IFADDR)
 
 target_link_libraries (nanomsg ws2_32)
 target_link_libraries (nanomsg Mswsock.lib)

--- a/src/transports/utils/iface.c
+++ b/src/transports/utils/iface.c
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
+    Copyright 2015 Garrett D'Amore <garrett@damore.org>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -37,179 +38,9 @@
 static void nn_iface_any (int ipv4only, struct sockaddr_storage *result,
     size_t *resultlen);
 
-#if defined NN_USE_IFADDRS
-
-#include <ifaddrs.h>
-
-static int nn_is_v4_unicast (const struct sockaddr *sa)
-{
-    const struct sockaddr_in *sin = (const void *)sa;
-    if (sa->sa_family != AF_INET)
-        return 0;
-    if ((ntohl(sin->sin_addr.s_addr) & 0xF0000000U) == 0xE0000000U) {
-        return 1;
-    }
-    return 0;
-}
-
-static int nn_is_v6_unicast (const struct sockaddr *sa)
-{
-    const struct sockaddr_in6 *sin6 = (const void *)sa;
-    if (sa->sa_family != AF_INET6)
-        return 0;
-    if (sin6->sin6_addr.s6_addr[0] == 0xff)
-        return 0;
-    return 1;
-}
-
-int nn_iface_resolve (const char *addr, size_t addrlen, int ipv4only,
-    struct sockaddr_storage *result, size_t *resultlen)
-{
-    int rc;
-    struct ifaddrs *ifaces;
-    struct ifaddrs *it;
-    struct ifaddrs *ipv4;
-    struct ifaddrs *ipv6;
-    size_t ifalen;
-
-    /*  Asterisk is a special name meaning "all interfaces". */
-    if (addrlen == 1 && addr [0] == '*') {
-        nn_iface_any (ipv4only, result, resultlen);
-        return 0;
-    }
-
-    /*  Try to resolve the supplied string as a literal address. */
-    rc = nn_literal_resolve (addr, addrlen, ipv4only, result, resultlen);
-    if (rc == 0)
-        return 0;
-    errnum_assert (rc == -EINVAL, -rc);
-
-    /*  Get the list of local network interfaces from the system. */
-    ifaces = NULL;
-    rc = getifaddrs (&ifaces);
-    errno_assert (rc == 0);
-    nn_assert (ifaces);
-
-    /*  Find the NIC with the specified name. */
-    ipv4 = NULL;
-    ipv6 = NULL;
-    for (it = ifaces; it != NULL; it = it->ifa_next) {
-        if (!it->ifa_addr)
-            continue;
-        ifalen = strlen (it->ifa_name);
-        if (ifalen != addrlen || memcmp (it->ifa_name, addr, addrlen) != 0)
-            continue;
-
-        /*  We choose the first unicast address found on the interface.  This
-         *  may well not be what you'd prefer.  If you care about this, bind
-         *  to a specific IP address instead of an interface.
-         */
-        switch (it->ifa_addr->sa_family) {
-        case AF_INET:
-            if (!nn_is_v4_unicast(it->ifa_addr))
-                continue;
-            ipv4 = it;
-            break;
-        case AF_INET6:
-            if (!nn_is_v6_unicast(it->ifa_addr))
-                continue;
-            ipv6 = it;
-            break;
-        }
-    }
-
-    /*  IPv6 address is preferable. */
-    if (ipv6 && !ipv4only) {
-        if (result) {
-            result->ss_family = AF_INET6;
-            memcpy (result, ipv6->ifa_addr, sizeof (struct sockaddr_in6));
-        }
-        if (resultlen)
-            *resultlen = sizeof (struct sockaddr_in6);
-        freeifaddrs (ifaces);
-        return 0;
-    }
-
-    /*  Use IPv4 address. */
-    if (ipv4) {
-        if (result) {
-            result->ss_family = AF_INET;
-            memcpy (result, ipv4->ifa_addr, sizeof (struct sockaddr_in));
-        }
-        if (resultlen)
-            *resultlen = sizeof (struct sockaddr_in);
-        freeifaddrs (ifaces);
-        return 0;
-    }
-
-    /*  There's no such interface. */
-    freeifaddrs (ifaces);
-    return -ENODEV;
-}
-
-#endif
-
-#if defined NN_USE_SIOCGIFADDR
-
-#include <unistd.h>
-#include <sys/ioctl.h>
-#include <net/if.h>
-
-int nn_iface_resolve (const char *addr, size_t addrlen, int ipv4only,
-    struct sockaddr_storage *result, size_t *resultlen)
-{
-    int rc;
-    int s;
-    struct ifreq req;
-
-    /*  Asterisk is a special name meaning "all interfaces". */
-    if (addrlen == 1 && addr [0] == '*') {
-        nn_iface_any (ipv4only, result, resultlen);
-        return 0;
-    }
-
-    /*  Open the helper socket. */
-#ifdef SOCK_CLOEXEC
-    s = socket (AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
-#else
-    s = socket (AF_INET, SOCK_DGRAM, 0);
-#endif
-    errno_assert (s != -1);
-
-    /*  Create the interface name resolution request. */
-    if (sizeof (req.ifr_name) <= addrlen) {
-        nn_closefd (s);
-        return -ENODEV;
-    }
-    memcpy (req.ifr_name, addr, addrlen);
-    req.ifr_name [addrlen] = 0;
-
-    /*  Execute the request. */
-    rc = ioctl (s, SIOCGIFADDR, (caddr_t) &req, sizeof (struct ifreq));
-    if (rc == -1) {
-        nn_closefd (s);
-        return -ENODEV;
-    }
-
-    /*  Interface name resolution succeeded. Return the address to the user. */
-    /*  TODO: What about IPv6 addresses? */
-    nn_assert (req.ifr_addr.sa_family == AF_INET);
-    if (result)
-        memcpy (result, (struct sockaddr_in*) &req.ifr_addr,
-            sizeof (struct sockaddr_in));
-    if (resultlen)
-        *resultlen = sizeof (struct sockaddr_in);
-    nn_closefd (s);
-    return 0;
-}
-
-#endif
-
-#if defined NN_USE_LITERAL_IFADDR
-
-/*  The last resort case. If we haven't found any mechanism for turning
-    NIC names into addresses, we'll try to resolve the string as an address
-    literal. */
+/*  We no longer resolve interface names.  This feature was non-portable
+    and fragile.  Only IP addresses may be used.  They are provided in
+    the form of string literals. */
 int nn_iface_resolve (const char *addr, size_t addrlen, int ipv4only,
     struct sockaddr_storage *result, size_t *resultlen)
 {
@@ -221,16 +52,12 @@ int nn_iface_resolve (const char *addr, size_t addrlen, int ipv4only,
         return 0;
     }
 
-    /*  On Windows there are no sane network interface names. We'll treat the
-        name as a IP address literal. */
     rc = nn_literal_resolve (addr, addrlen, ipv4only, result, resultlen);
     if (rc == -EINVAL)
         return -ENODEV;
     errnum_assert (rc == 0, -rc);
     return 0;
 }
-
-#endif
 
 static void nn_iface_any (int ipv4only, struct sockaddr_storage *result,
     size_t *resultlen)
@@ -254,4 +81,3 @@ static void nn_iface_any (int ipv4only, struct sockaddr_storage *result,
             *resultlen = sizeof (struct sockaddr_in6);
     }
 }
-


### PR DESCRIPTION
This eliminates the support for named interfaces in nanomsg URLs.  It only ever worked on a subset of platforms, and that was inconsistent.  We require a literal IP address to be supplied now.