### PR TITLE
fixes #502 Assertion or Access Violation when calling nn_close while nn_recv blocks in separate thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_libnanomsg_test (survey)
 add_libnanomsg_test (bus)
 
 #  Feature tests.
+add_libnanomsg_test (async_shutdown)
 add_libnanomsg_test (block)
 add_libnanomsg_test (term)
 add_libnanomsg_test (timeo)

--- a/Makefile.am
+++ b/Makefile.am
@@ -485,6 +485,7 @@ PROTOCOL_TESTS = \
     tests/bus
 
 FEATURE_TESTS = \
+    tests/async_shutdown \
     tests/block \
     tests/term \
     tests/timeo \

--- a/src/utils/err.c
+++ b/src/utils/err.c
@@ -160,6 +160,8 @@ int nn_err_wsa_to_posix (int wsaerr)
         return ECONNABORTED;
     case WSAECONNRESET:
         return ECONNRESET;
+    case WSAENOTSOCK:
+        return ENOTSOCK;
     case ERROR_BROKEN_PIPE:
         return ECONNRESET;
     case WSAESOCKTNOSUPPORT:

--- a/tests/async_shutdown.c
+++ b/tests/async_shutdown.c
@@ -1,0 +1,76 @@
+/*
+    Copyright (c) 2012 Martin Sustrik  All rights reserved.
+    Copyright (c) 2015 Jack R. Dunaway.  All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom
+    the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#include "../src/nn.h"
+#include "../src/pair.h"
+#include "../src/pubsub.h"
+#include "../src/pipeline.h"
+#include "../src/tcp.h"
+
+#include "testutil.h"
+#include "../src/utils/attr.h"
+#include "../src/utils/thread.c"
+#include "../src/utils/atomic.c"
+
+/*  Test condition of closing sockets that are blocking in another thread. */
+
+#define TEST_LOOPS 10
+#define SOCKET_ADDRESS "tcp://127.0.0.1:5557"
+
+struct nn_atomic active;
+
+static void routine (NN_UNUSED void *arg)
+{
+    int s;
+    int rc;
+    int msg;
+
+    nn_assert (arg);
+
+    s = *((int *) arg);
+
+    /*  We don't expect to actually receive a message here;
+        therefore, the datatype of 'msg' is irrelevant. */
+    rc = nn_recv (s, &msg, sizeof(msg), 0);
+
+    errno_assert (nn_errno () == EINTR);
+}
+
+int main ()
+{
+    int sb;
+    int i;
+    struct nn_thread thread;
+
+    for (i = 0; i != TEST_LOOPS; ++i) {
+        sb = test_socket (AF_SP, NN_PULL);
+        test_bind (sb, SOCKET_ADDRESS);
+        nn_sleep (100);
+        nn_thread_init (&thread, routine, &sb);
+        nn_sleep (100);
+        test_close (sb);
+        nn_thread_term (&thread);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR replaces #502 by splitting out the test from `tcp_shutdown` into a new test called `async_shutdown`

Again, for clarity, this PR fixes one type of bug on Windows, but then exposes a new failure mode downstream. The test -- but not the fix -- might expose further issues on *NIX systems.