### PR TITLE
fixes #65 nn_close should abort blocking calls on socket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_libnanomsg_test (survey)
 add_libnanomsg_test (bus)
 
 #  Feature tests.
+add_libnanomsg_test (async_shutdown)
 add_libnanomsg_test (block)
 add_libnanomsg_test (term)
 add_libnanomsg_test (timeo)

--- a/Makefile.am
+++ b/Makefile.am
@@ -485,6 +485,7 @@ PROTOCOL_TESTS = \
     tests/bus
 
 FEATURE_TESTS = \
+    tests/async_shutdown \
     tests/block \
     tests/term \
     tests/timeo \

--- a/src/core/global.c
+++ b/src/core/global.c
@@ -101,19 +101,6 @@
     the type should be changed to uint32_t or int. */
 CT_ASSERT (NN_MAX_SOCKETS <= 0x10000);
 
-/*  This check is performed at the beginning of each socket operation to make
-    sure that the library was initialised, the socket actually exists, and is
-    a valid socket index. */
-#define NN_BASIC_CHECKS \
-    if (nn_slow (s < 0 || s > NN_MAX_SOCKETS)) {\
-        errno = EBADF;\
-        return -1;\
-        }\
-    if (nn_slow (!self.socks || !self.socks [s])) {\
-        errno = EBADF;\
-        return -1;\
-    }
-
 #define NN_CTX_FLAG_ZOMBIE 1
 
 #define NN_GLOBAL_SRC_STAT_TIMER 1
@@ -139,10 +126,12 @@ struct nn_global {
     /*  Combination of the flags listed above. */
     int flags;
 
-    /*  List of all available transports. */
+    /*  List of all available transports.  Note that this list is not
+        dynamic; i.e. it is created during global initialization and
+        is never modified. */
     struct nn_list transports;
 
-    /*  List of all available socket types. */
+    /*  List of all available socket types.  Again this list is not dynamic.*/
     struct nn_list socktypes;
 
     /*  Pool of worker threads. */
@@ -178,7 +167,7 @@ static void nn_global_add_socktype (struct nn_socktype *socktype);
 
 /*  Private function that unifies nn_bind and nn_connect functionality.
     It returns the ID of the newly created endpoint. */
-static int nn_global_create_ep (int s, const char *addr, int bind);
+static int nn_global_create_ep (struct nn_sock *, const char *addr, int bind);
 
 /*  Private socket creator which doesn't initialize global state and
     does no locking by itself */
@@ -190,6 +179,10 @@ static void nn_global_handler (struct nn_fsm *self,
 static void nn_global_shutdown (struct nn_fsm *self,
     int src, int type, void *srcptr);
 
+/*  Socket holds. */
+static int nn_global_hold_socket(struct nn_sock **sockp, int s);
+static int nn_global_hold_socket_locked(struct nn_sock **sockp, int s);
+static void nn_global_rele_socket(struct nn_sock *);
 
 int nn_errno (void)
 {
@@ -304,7 +297,7 @@ static void nn_global_init (void)
         self.statistics_socket = nn_global_create_socket (AF_SP, NN_PUB);
         errno_assert (self.statistics_socket >= 0);
 
-        rc = nn_global_create_ep (self.statistics_socket, addr, 0);
+        rc = nn_global_create_ep (self.socks[self.statistics_socket], addr, 0);
         errno_assert (rc >= 0);
     } else {
         self.statistics_socket = -1;
@@ -555,7 +548,7 @@ int nn_socket (int domain, int protocol)
 
     rc = nn_global_create_socket (domain, protocol);
 
-    if(rc < 0) {
+    if (rc < 0) {
         nn_global_term ();
         nn_glock_unlock ();
         errno = -rc;
@@ -570,27 +563,46 @@ int nn_socket (int domain, int protocol)
 int nn_close (int s)
 {
     int rc;
+    struct nn_sock *sock;
 
-    NN_BASIC_CHECKS;
-
-    /*  TODO: nn_sock_term can take a long time to accomplish. It should not be
-        performed under global critical section. */
     nn_glock_lock ();
-
-    /*  Deallocate the socket object. */
-    rc = nn_sock_term (self.socks [s]);
-    if (nn_slow (rc == -EINTR)) {
+    rc = nn_global_hold_socket_locked (&sock, s);
+    if (nn_slow (rc < 0)) {
         nn_glock_unlock ();
+        errno = -rc;
+        return -1;
+    }
+
+    /*  Start the shutdown process on the socket.  This will cause
+        all other socket users, as well as endpoints, to begin cleaning up.
+        This is done with the glock held to ensure that two instances
+        of nn_close can't access the same socket. */
+
+    nn_sock_stop (sock);
+    nn_glock_unlock ();
+
+    /*  We have to drop both the hold we just acquired, as well as
+        the original hold, in order for nn_sock_term to complete. */
+    nn_sock_rele (sock);
+    nn_sock_rele (sock);
+
+    /*  Now clean up.  The termination routine below will block until
+        all other consumers of the socket have dropped their holds, and
+        all endpoints have cleanly exited. */
+    rc = nn_sock_term (sock);
+    if (nn_slow (rc == -EINTR)) {
+        nn_global_rele_socket (sock);
         errno = EINTR;
         return -1;
     }
 
     /*  Remove the socket from the socket table, add it to unused socket
         table. */
-    nn_free (self.socks [s]);
+    nn_glock_lock ();
     self.socks [s] = NULL;
     self.unused [NN_MAX_SOCKETS - self.nsocks] = s;
     --self.nsocks;
+    nn_free (sock);
 
     /*  Destroy the global context if there's no socket remaining. */
     nn_global_term ();
@@ -604,97 +616,126 @@ int nn_setsockopt (int s, int level, int option, const void *optval,
     size_t optvallen)
 {
     int rc;
+    struct nn_sock *sock;
 
-    NN_BASIC_CHECKS;
-
-    if (nn_slow (!optval && optvallen)) {
-        errno = EFAULT;
-        return -1;
-    }
-
-    nn_glock_lock ();
-    rc = nn_sock_setopt (self.socks [s], level, option, optval, optvallen);
-    nn_glock_unlock ();
+    rc = nn_global_hold_socket (&sock, s);
     if (nn_slow (rc < 0)) {
         errno = -rc;
         return -1;
     }
-    errnum_assert (rc == 0, -rc);
 
+    if (nn_slow (!optval && optvallen)) {
+        rc = -EFAULT;
+        goto fail;
+    }
+
+    rc = nn_sock_setopt (sock, level, option, optval, optvallen);
+    if (nn_slow (rc < 0))
+        goto fail;
+    errnum_assert (rc == 0, -rc);
+    nn_global_rele_socket (sock);
     return 0;
+
+fail:
+    nn_global_rele_socket (sock);
+    errno = -rc;
+    return -1;
 }
 
 int nn_getsockopt (int s, int level, int option, void *optval,
     size_t *optvallen)
 {
     int rc;
+    struct nn_sock *sock;
 
-    NN_BASIC_CHECKS;
-
-    if (nn_slow (!optval && optvallen)) {
-        errno = EFAULT;
-        return -1;
-    }
-
-    nn_glock_lock ();
-    rc = nn_sock_getopt (self.socks [s], level, option, optval, optvallen);
-    nn_glock_unlock ();
+    rc = nn_global_hold_socket (&sock, s);
     if (nn_slow (rc < 0)) {
         errno = -rc;
         return -1;
     }
-    errnum_assert (rc == 0, -rc);
 
+    if (nn_slow (!optval && optvallen)) {
+        rc = -EFAULT;
+        goto fail;
+    }
+
+    rc = nn_sock_getopt (sock, level, option, optval, optvallen);
+    if (nn_slow (rc < 0))
+        goto fail;
+    errnum_assert (rc == 0, -rc);
+    nn_global_rele_socket (sock);
     return 0;
+
+fail:
+    nn_global_rele_socket (sock);
+    errno = -rc;
+    return -1;
 }
 
 int nn_bind (int s, const char *addr)
 {
     int rc;
+    struct nn_sock *sock;
 
-    NN_BASIC_CHECKS;
-
-    nn_glock_lock();
-    rc = nn_global_create_ep (s, addr, 1);
-    nn_glock_unlock();
+    rc = nn_global_hold_socket (&sock, s);
     if (rc < 0) {
         errno = -rc;
         return -1;
     }
 
+    rc = nn_global_create_ep (sock, addr, 1);
+    if (nn_slow (rc < 0)) {
+        nn_global_rele_socket (sock);
+        errno = -rc;
+        return -1;
+    }
+
+    nn_global_rele_socket (sock);
     return rc;
 }
 
 int nn_connect (int s, const char *addr)
 {
     int rc;
+    struct nn_sock *sock;
 
-    NN_BASIC_CHECKS;
-
-    nn_glock_lock();
-    rc = nn_global_create_ep (s, addr, 0);
-    nn_glock_unlock();
-    if (rc < 0) {
+    rc = nn_global_hold_socket (&sock, s);
+    if (nn_slow (rc < 0)) {
         errno = -rc;
         return -1;
     }
 
+    rc = nn_global_create_ep (sock, addr, 0);
+    if (rc < 0) {
+        nn_global_rele_socket (sock);
+        errno = -rc;
+        return -1;
+    }
+
+    nn_global_rele_socket (sock);
     return rc;
 }
 
 int nn_shutdown (int s, int how)
 {
     int rc;
+    struct nn_sock *sock;
 
-    NN_BASIC_CHECKS;
-
-    rc = nn_sock_rm_ep (self.socks [s], how);
+    rc = nn_global_hold_socket (&sock, s);
     if (nn_slow (rc < 0)) {
+        errno = -rc;
+        return -1;
+    }
+
+    rc = nn_sock_rm_ep (sock, how);
+    if (nn_slow (rc < 0)) {
+        nn_global_rele_socket (sock);
         errno = -rc;
         return -1;
     }
     nn_assert (rc == 0);
 
+    nn_global_rele_socket (sock);
     return 0;
 }
 
@@ -741,24 +782,29 @@ int nn_sendmsg (int s, const struct nn_msghdr *msghdr, int flags)
     void *chunk;
     int nnmsg;
     struct nn_cmsghdr *cmsg;
+    struct nn_sock *sock;
 
-    NN_BASIC_CHECKS;
-
-    if (nn_slow (!msghdr)) {
-        errno = EINVAL;
+    rc = nn_global_hold_socket (&sock, s);
+    if (nn_slow (rc < 0)) {
+        errno = -rc;
         return -1;
     }
 
+    if (nn_slow (!msghdr)) {
+        rc = -EINVAL;
+        goto fail;
+    }
+
     if (nn_slow (msghdr->msg_iovlen < 0)) {
-        errno = EMSGSIZE;
-        return -1;
+        rc = -EMSGSIZE;
+        goto fail;
     }
 
     if (msghdr->msg_iovlen == 1 && msghdr->msg_iov [0].iov_len == NN_MSG) {
         chunk = *(void**) msghdr->msg_iov [0].iov_base;
         if (nn_slow (chunk == NULL)) {
-            errno = EFAULT;
-            return -1;
+            rc = -EFAULT;
+            goto fail;
         }
         sz = nn_chunk_size (chunk);
         nn_msg_init_chunk (&msg, chunk);
@@ -771,16 +817,16 @@ int nn_sendmsg (int s, const struct nn_msghdr *msghdr, int flags)
         for (i = 0; i != msghdr->msg_iovlen; ++i) {
             iov = &msghdr->msg_iov [i];
             if (nn_slow (iov->iov_len == NN_MSG)) {
-               errno = EINVAL;
-               return -1;
+               rc = -EINVAL;
+               goto fail;
             }
             if (nn_slow (!iov->iov_base && iov->iov_len)) {
-                errno = EFAULT;
-                return -1;
+                rc = -EFAULT;
+                goto fail;
             }
             if (nn_slow (sz + iov->iov_len < sz)) {
-                errno = EINVAL;
-                return -1;
+                rc = -EINVAL;
+                goto fail;
             }
             sz += iov->iov_len;
         }
@@ -832,7 +878,7 @@ int nn_sendmsg (int s, const struct nn_msghdr *msghdr, int flags)
     }
 
     /*  Send it further down the stack. */
-    rc = nn_sock_send (self.socks [s], &msg, flags);
+    rc = nn_sock_send (sock, &msg, flags);
     if (nn_slow (rc < 0)) {
 
         /*  If we are dealing with user-supplied buffer, detach it from
@@ -841,15 +887,22 @@ int nn_sendmsg (int s, const struct nn_msghdr *msghdr, int flags)
             nn_chunkref_init (&msg.body, 0);
 
         nn_msg_term (&msg);
-        errno = -rc;
-        return -1;
+        goto fail;
     }
 
     /*  Adjust the statistics. */
-    nn_sock_stat_increment (self.socks [s], NN_STAT_MESSAGES_SENT, 1);
-    nn_sock_stat_increment (self.socks [s], NN_STAT_BYTES_SENT, sz);
+    nn_sock_stat_increment (sock, NN_STAT_MESSAGES_SENT, 1);
+    nn_sock_stat_increment (sock, NN_STAT_BYTES_SENT, sz);
+
+    nn_global_rele_socket (sock);
 
     return (int) sz;
+
+fail:
+    nn_global_rele_socket (sock);
+
+    errno = -rc;
+    return -1;
 }
 
 int nn_recvmsg (int s, struct nn_msghdr *msghdr, int flags)
@@ -867,24 +920,28 @@ int nn_recvmsg (int s, struct nn_msghdr *msghdr, int flags)
     size_t spsz;
     size_t sptotalsz;
     struct nn_cmsghdr *chdr;
+    struct nn_sock *sock;
 
-    NN_BASIC_CHECKS;
-
-    if (nn_slow (!msghdr)) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    if (nn_slow (msghdr->msg_iovlen < 0)) {
-        errno = EMSGSIZE;
-        return -1;
-    }
-
-    /*  Get a message. */
-    rc = nn_sock_recv (self.socks [s], &msg, flags);
+    rc = nn_global_hold_socket (&sock, s);
     if (nn_slow (rc < 0)) {
         errno = -rc;
         return -1;
+    }
+
+    if (nn_slow (!msghdr)) {
+        rc = -EINVAL;
+        goto fail;
+    }
+
+    if (nn_slow (msghdr->msg_iovlen < 0)) {
+        rc = -EMSGSIZE;
+        goto fail;
+    }
+
+    /*  Get a message. */
+    rc = nn_sock_recv (sock, &msg, flags);
+    if (nn_slow (rc < 0)) {
+        goto fail;
     }
 
     if (msghdr->msg_iovlen == 1 && msghdr->msg_iov [0].iov_len == NN_MSG) {
@@ -901,8 +958,8 @@ int nn_recvmsg (int s, struct nn_msghdr *msghdr, int flags)
             iov = &msghdr->msg_iov [i];
             if (nn_slow (iov->iov_len == NN_MSG)) {
                 nn_msg_term (&msg);
-                errno = EINVAL;
-                return -1;
+                rc = -EINVAL;
+                goto fail;
             }
             if (iov->iov_len > sz) {
                 memcpy (iov->iov_base, data, sz);
@@ -962,10 +1019,18 @@ int nn_recvmsg (int s, struct nn_msghdr *msghdr, int flags)
     nn_msg_term (&msg);
 
     /*  Adjust the statistics. */
-    nn_sock_stat_increment (self.socks [s], NN_STAT_MESSAGES_RECEIVED, 1);
-    nn_sock_stat_increment (self.socks [s], NN_STAT_BYTES_RECEIVED, sz);
+    nn_sock_stat_increment (sock, NN_STAT_MESSAGES_RECEIVED, 1);
+    nn_sock_stat_increment (sock, NN_STAT_BYTES_RECEIVED, sz);
+
+    nn_global_rele_socket (sock);
 
     return (int) sz;
+
+fail:
+    nn_global_rele_socket (sock);
+
+    errno = -rc;
+    return -1;
 }
 
 static void nn_global_add_transport (struct nn_transport *transport)
@@ -974,7 +1039,6 @@ static void nn_global_add_transport (struct nn_transport *transport)
         transport->init ();
     nn_list_insert (&self.transports, &transport->item,
         nn_list_end (&self.transports));
-
 }
 
 static void nn_global_add_socktype (struct nn_socktype *socktype)
@@ -1184,7 +1248,8 @@ static void nn_global_submit_statistics ()
     }
 }
 
-static int nn_global_create_ep (int s, const char *addr, int bind)
+static int nn_global_create_ep (struct nn_sock *sock, const char *addr,
+    int bind)
 {
     int rc;
     const char *proto;
@@ -1227,13 +1292,12 @@ static int nn_global_create_ep (int s, const char *addr, int bind)
     }
 
     /*  Ask the socket to create the endpoint. */
-    rc = nn_sock_add_ep (self.socks [s], tp, bind, addr);
+    rc = nn_sock_add_ep (sock, tp, bind, addr);
     return rc;
 }
 
 struct nn_transport *nn_global_transport (int id)
 {
-    /*  This function must be called with the nn_glock_lock held. */
     struct nn_transport *tp;
     struct nn_list_item *it;
 
@@ -1344,4 +1408,50 @@ static void nn_global_shutdown (struct nn_fsm *self,
 
 int nn_global_print_errors () {
     return self.print_errors;
+}
+
+/*  Get the socket structure for a socket id.  This must be called under
+    the global lock (nn_glock_lock.)  The socket itself will not be freed
+    while the hold is active. */
+int nn_global_hold_socket_locked(struct nn_sock **sockp, int s)
+{
+    struct nn_sock *sock;
+
+    if (nn_slow (self.socks == NULL)) {
+        *sockp = NULL;
+        return -ETERM;
+    }
+    if (nn_slow ((self.flags & NN_CTX_FLAG_ZOMBIE) != 0)) {
+        *sockp = NULL;
+        return -ETERM;
+    }
+
+    if (nn_slow (s < 0 || s >= NN_MAX_SOCKETS))
+        return -EBADF;
+
+    sock = self.socks[s];
+    if (nn_slow (sock == NULL))
+        return -EBADF;
+
+    if (nn_slow (nn_sock_hold (sock) != 0)) {
+        return -EBADF;
+    }
+    *sockp = sock;
+    return 0;
+}
+
+int nn_global_hold_socket(struct nn_sock **sockp, int s)
+{
+    int rc;
+    nn_glock_lock();
+    rc = nn_global_hold_socket_locked(sockp, s);
+    nn_glock_unlock();
+    return rc;
+}
+
+void nn_global_rele_socket(struct nn_sock *sock)
+{
+    nn_glock_lock();
+    nn_sock_rele(sock);
+    nn_glock_unlock();
 }

--- a/src/core/sock.c
+++ b/src/core/sock.c
@@ -1,6 +1,7 @@
 /*
     Copyright (c) 2012-2014 Martin Sustrik  All rights reserved.
     Copyright (c) 2013 GoPivotal, Inc.  All rights reserved.
+    Copyright 2015 Garrett D'Amore <garrett@damore.org>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -48,6 +49,7 @@
 #define NN_SOCK_STATE_ZOMBIE 3
 #define NN_SOCK_STATE_STOPPING_EPS 4
 #define NN_SOCK_STATE_STOPPING 5
+#define NN_SOCK_STATE_FINI 6
 
 /*  Events sent to the state machine. */
 #define NN_SOCK_ACTION_ZOMBIFY 1
@@ -67,6 +69,8 @@ static void nn_sock_shutdown (struct nn_fsm *self, int src, int type,
     void *srcptr);
 static void nn_sock_action_zombify (struct nn_sock *self);
 
+/*  Initialize a socket.  A hold is placed on the initialized socket for
+    the caller as well. */
 int nn_sock_init (struct nn_sock *self, struct nn_socktype *socktype, int fd)
 {
     int rc;
@@ -104,6 +108,7 @@ int nn_sock_init (struct nn_sock *self, struct nn_socktype *socktype, int fd)
         }
     }
     nn_sem_init (&self->termsem);
+    nn_sem_init (&self->relesem);
     if (nn_slow (rc < 0)) {
         if (!(socktype->flags & NN_SOCKTYPE_FLAG_NORECV))
             nn_efd_term (&self->rcvfd);
@@ -112,6 +117,7 @@ int nn_sock_init (struct nn_sock *self, struct nn_socktype *socktype, int fd)
         return rc;
     }
 
+    self->holds = 1;   /*  Callers hold. */
     self->flags = 0;
     nn_clock_init (&self->clock);
     nn_list_init (&self->eps);
@@ -188,31 +194,54 @@ void nn_sock_zombify (struct nn_sock *self)
     nn_ctx_leave (&self->ctx);
 }
 
+/*  Stop the socket.  This will prevent new calls from aquiring a
+    hold on the socket, cause endpoints to shut down, and wake any
+    threads waiting to recv or send data. */
+void nn_sock_stop (struct nn_sock *self)
+{
+    nn_ctx_enter (&self->ctx);
+    nn_fsm_stop (&self->fsm);
+    nn_ctx_leave (&self->ctx);
+}
+
 int nn_sock_term (struct nn_sock *self)
 {
     int rc;
     int i;
 
-    /*  Ask the state machine to start closing the socket. */
-    nn_ctx_enter (&self->ctx);
-    nn_fsm_stop (&self->fsm);
-    nn_ctx_leave (&self->ctx);
+    /*  NOTE: nn_sock_stop must have already been called. */
 
-    /*  Shutdown process was already started but some endpoints may still
-        alive. Here we are going to wait till they are all closed. */
-    rc = nn_sem_wait (&self->termsem);
-    if (nn_slow (rc == -EINTR))
-        return -EINTR;
-    errnum_assert (rc == 0, -rc);
+    /*  Some endpoints may still be alive.  Here we are going to wait
+        till they are all closed.  This loop is not interruptible, because
+        making it so would leave a partially cleaned up socket, and we don't
+        have a way to defer resource deallocation. */
+    for (;;) {
+        rc = nn_sem_wait (&self->termsem);
+        if (nn_slow (rc == -EINTR))
+            continue;
+        errnum_assert (rc == 0, -rc);
+        break;
+    }
 
-    /*  The thread that posted the semaphore can still have the ctx locked
+    /*  Also, wait for all holds on the socket to be released.  */
+    for (;;) {
+        rc = nn_sem_wait (&self->relesem);
+        if (nn_slow (rc == -EINTR))
+            continue;
+        errnum_assert (rc == 0, -rc);
+        break;
+    }
+
+    /*  Threads that posted the semaphore(s) can still have the ctx locked
         for a short while. By simply entering the context and exiting it
-        immediately we can be sure that the thread in question have already
+        immediately we can be sure that any such threads have already
         exited the context. */
     nn_ctx_enter (&self->ctx);
     nn_ctx_leave (&self->ctx);
 
-    /*  Deallocate the resources. */
+    /*  At this point, we can be reasonably certain that no other thread
+        has any references to the socket. */
+
     nn_fsm_stopped_noevent (&self->fsm);
     nn_fsm_term (&self->fsm);
     nn_sem_term (&self->termsem);
@@ -569,10 +598,27 @@ int nn_sock_send (struct nn_sock *self, struct nn_msg *msg, int flags)
 
     while (1) {
 
-        /*  If nn_term() was already called, return ETERM. */
-        if (nn_slow (self->state == NN_SOCK_STATE_ZOMBIE)) {
+        switch (self->state) {
+        case NN_SOCK_STATE_ACTIVE:
+        case NN_SOCK_STATE_INIT:
+             break;
+
+        case NN_SOCK_STATE_ZOMBIE:
+            /*  If nn_term() was already called, return ETERM. */
             nn_ctx_leave (&self->ctx);
             return -ETERM;
+
+        case NN_SOCK_STATE_STOPPING_EPS:
+        case NN_SOCK_STATE_STOPPING:
+        case NN_SOCK_STATE_FINI:
+            /*  Socket closed or closing.  Should we return something
+                else here; recvmsg(2) for example returns no data in
+                this case, like read(2).  The use of indexed file
+                descriptors is further problematic, as an FD can be reused
+                leading to situations where technically the outstanding
+                operation should refer to some other socket entirely.  */
+            nn_ctx_leave (&self->ctx);
+            return -EBADF;
         }
 
         /*  Try to send the message in a non-blocking way. */
@@ -604,6 +650,8 @@ int nn_sock_send (struct nn_sock *self, struct nn_msg *msg, int flags)
             return -ETIMEDOUT;
         if (nn_slow (rc == -EINTR))
             return -EINTR;
+        if (nn_slow (rc == -EBADF))
+            return -EBADF;
         errnum_assert (rc == 0, rc);
         nn_ctx_enter (&self->ctx);
         /*
@@ -647,10 +695,27 @@ int nn_sock_recv (struct nn_sock *self, struct nn_msg *msg, int flags)
 
     while (1) {
 
-        /*  If nn_term() was already called, return ETERM. */
-        if (nn_slow (self->state == NN_SOCK_STATE_ZOMBIE)) {
+        switch (self->state) {
+        case NN_SOCK_STATE_ACTIVE:
+        case NN_SOCK_STATE_INIT:
+             break;
+
+        case NN_SOCK_STATE_ZOMBIE:
+            /*  If nn_term() was already called, return ETERM. */
             nn_ctx_leave (&self->ctx);
             return -ETERM;
+
+        case NN_SOCK_STATE_STOPPING_EPS:
+        case NN_SOCK_STATE_STOPPING:
+        case NN_SOCK_STATE_FINI:
+            /*  Socket closed or closing.  Should we return something
+                else here; recvmsg(2) for example returns no data in
+                this case, like read(2).  The use of indexed file
+                descriptors is further problematic, as an FD can be reused
+                leading to situations where technically the outstanding
+                operation should refer to some other socket entirely.  */
+            nn_ctx_leave (&self->ctx);
+            return -EBADF;
         }
 
         /*  Try to receive the message in a non-blocking way. */
@@ -682,6 +747,8 @@ int nn_sock_recv (struct nn_sock *self, struct nn_msg *msg, int flags)
             return -ETIMEDOUT;
         if (nn_slow (rc == -EINTR))
             return -EINTR;
+        if (nn_slow (rc == -EBADF))
+            return -EBADF;
         errnum_assert (rc == 0, rc);
         nn_ctx_enter (&self->ctx);
         /*
@@ -809,12 +876,10 @@ static void nn_sock_shutdown (struct nn_fsm *self, int src, int type,
         /*  Close sndfd and rcvfd. This should make any current
             select/poll using SNDFD and/or RCVFD exit. */
         if (!(sock->socktype->flags & NN_SOCKTYPE_FLAG_NORECV)) {
-            nn_efd_term (&sock->rcvfd);
-            memset (&sock->rcvfd, 0xcd, sizeof (sock->rcvfd));
+            nn_efd_stop (&sock->rcvfd);
         }
         if (!(sock->socktype->flags & NN_SOCKTYPE_FLAG_NOSEND)) {
-            nn_efd_term (&sock->sndfd);
-            memset (&sock->sndfd, 0xcd, sizeof (sock->sndfd));
+            nn_efd_stop (&sock->sndfd);
         }
 
         /*  Ask all the associated endpoints to stop. */
@@ -869,7 +934,15 @@ finish1:
         /*  Protocol-specific part of the socket is stopped.
             We can safely deallocate it. */
         sock->sockbase->vfptr->destroy (sock->sockbase);
-        sock->state = NN_SOCK_STATE_INIT;
+        sock->state = NN_SOCK_STATE_FINI;
+
+        /*  Close the event FDs entirely. */
+        if (!(sock->socktype->flags & NN_SOCKTYPE_FLAG_NORECV)) {
+            nn_efd_term (&sock->rcvfd);
+        }
+        if (!(sock->socktype->flags & NN_SOCKTYPE_FLAG_NOSEND)) {
+            nn_efd_term (&sock->sndfd);
+        }
 
         /*  Now we can unblock the application thread blocked in
             the nn_close() call. */
@@ -1006,7 +1079,7 @@ void nn_sock_report_error (struct nn_sock *self, struct nn_ep *ep, int errnum)
     if (errnum == 0)
         return;
 
-    if(ep) {
+    if (ep) {
         fprintf(stderr, "nanomsg: socket.%s[%s]: Error: %s\n",
             self->socket_name, nn_ep_getaddr(ep), nn_strerror(errnum));
     } else {
@@ -1086,5 +1159,26 @@ void nn_sock_stat_increment (struct nn_sock *self, int name, int64_t increment)
             nn_assert(increment < INT_MAX && increment > -INT_MAX);
             self->statistics.current_ep_errors += (int) increment;
             break;
+    }
+}
+
+int nn_sock_hold (struct nn_sock *self)
+{
+    switch (self->state) {
+    case NN_SOCK_STATE_ACTIVE:
+    case NN_SOCK_STATE_INIT:
+        self->holds++;
+        return 0;
+    case NN_SOCK_STATE_ZOMBIE:
+        return -ETERM;
+    }
+    return -EBADF;
+}
+
+void nn_sock_rele (struct nn_sock *self)
+{
+    self->holds--;
+    if (self->holds == 0) {
+        nn_sem_post (&self->relesem);
     }
 }

--- a/src/core/sock.h
+++ b/src/core/sock.h
@@ -64,6 +64,7 @@ struct nn_sock
     struct nn_efd sndfd;
     struct nn_efd rcvfd;
     struct nn_sem termsem;
+    struct nn_sem relesem;
 
     /*  TODO: This clock can be accessed from different threads. If RDTSC
         is out-of-sync among different CPU cores, this can be a problem. */
@@ -77,6 +78,9 @@ struct nn_sock
 
     /*  Next endpoint ID to assign to a new endpoint. */
     int eid;
+
+    /*  Count of active holds against the socket. */
+    int holds;
 
     /*  Socket-level socket options. */
     int linger;
@@ -142,6 +146,9 @@ struct nn_sock
 /*  Initialise the socket. */
 int nn_sock_init (struct nn_sock *self, struct nn_socktype *socktype, int fd);
 
+/*  Called by nn_close() to stop activity on the socket.  It doesn't block. */
+void nn_sock_stop (struct nn_sock *self);
+
 /*  Called by nn_close() to deallocate the socket. It's a blocking function
     and can return -EINTR. */
 int nn_sock_term (struct nn_sock *self);
@@ -192,6 +199,10 @@ void nn_sock_rm (struct nn_sock *self, struct nn_pipe *pipe);
 /*  Monitoring callbacks  */
 void nn_sock_report_error(struct nn_sock *self, struct nn_ep *ep,  int errnum);
 void nn_sock_stat_increment(struct nn_sock *self, int name, int64_t increment);
+
+/*  Holds and releases. */
+int nn_sock_hold (struct nn_sock *self);
+void nn_sock_rele (struct nn_sock *self);
 
 #endif
 

--- a/src/devices/device.c
+++ b/src/devices/device.c
@@ -370,7 +370,7 @@ int nn_device_mvmsg (struct nn_device_recipe *device,
     hdr.msg_control = &control;
     hdr.msg_controllen = NN_MSG;
     rc = nn_recvmsg (from, &hdr, flags);
-    if (nn_slow (rc < 0 && nn_errno () == ETERM))
+    if (nn_slow (rc < 0 && (nn_errno () == ETERM || nn_errno () == EBADF)))
         return -1;
     errno_assert (rc >= 0);
     

--- a/src/utils/closefd.c
+++ b/src/utils/closefd.c
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2013 GoPivotal, Inc.  All rights reserved.
+    Copyright 2015 Garrett D'Amore <garrett@damore.org>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -31,7 +32,9 @@
 void nn_closefd (int fd)
 {
     int rc;
-
+    if (nn_slow (fd < 0)) {
+        return;
+    }
     rc = close (fd);
     if (nn_fast (rc == 0))
         return;

--- a/src/utils/efd.c
+++ b/src/utils/efd.c
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
+    Copyright 2015 Garrett D'Amore <garrett@damore.org>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -45,6 +46,8 @@ int nn_efd_wait (struct nn_efd *self, int timeout)
 
     pfd.fd = nn_efd_getfd (self);
     pfd.events = POLLIN;
+    if (nn_slow (pfd.fd < 0))
+        return -EBADF;
     rc = poll (&pfd, 1, timeout);
     if (nn_slow (rc < 0 && errno == EINTR))
         return -EINTR;
@@ -60,14 +63,31 @@ int nn_efd_wait (struct nn_efd *self, int timeout)
 {
     int rc;
     struct timeval tv;
+    int fd = self->r;
 
-    FD_SET (self->r, &self->fds);
+    if (nn_slow (fd < 0)) {
+        return -EBADF;
+    }
+    FD_SET (fd, &self->fds);
     if (timeout >= 0) {
         tv.tv_sec = timeout / 1000;
         tv.tv_usec = timeout % 1000 * 1000;
     }
     rc = select (0, &self->fds, NULL, NULL, timeout >= 0 ? &tv : NULL);
-    wsa_assert (rc != SOCKET_ERROR);
+
+    if (nn_slow (rc == SOCKET_ERROR)) {
+        rc = nn_err_wsa_to_posix (WSAGetLastError ());
+        errno = rc;
+        
+        /*  Treat these as a non-fatal errors, typically occuring when the
+            socket is being closed from a separate thread during a blocking
+            I/O operation. */
+        if (nn_fast (rc == EINTR || rc == ENOTSOCK))
+            return -EINTR;
+    }
+
+    wsa_assert (rc >= 0);
+
     if (nn_slow (rc == 0))
         return -ETIMEDOUT;
     return 0;
@@ -76,4 +96,3 @@ int nn_efd_wait (struct nn_efd *self, int timeout)
 #else
 #error
 #endif
-

--- a/src/utils/efd.h
+++ b/src/utils/efd.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
+    Copyright 2015 Garrett D'Amore <garrett@damore.org>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -50,6 +51,9 @@ void nn_efd_term (struct nn_efd *self);
 /*  Get the OS file descriptor that is readable when the efd object
     is signaled. */
 nn_fd nn_efd_getfd (struct nn_efd *self);
+
+/*  Stop the efd object. */
+void nn_efd_stop (struct nn_efd *self);
 
 /*  Switch the object into signaled state. */
 void nn_efd_signal (struct nn_efd *self);

--- a/src/utils/efd_eventfd.inc
+++ b/src/utils/efd_eventfd.inc
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
+    Copyright 2015 Garrett D'Amore <garrett@damore.org>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -49,7 +50,14 @@ int nn_efd_init (struct nn_efd *self)
 
 void nn_efd_term (struct nn_efd *self)
 {
-    nn_closefd (self->efd);
+    int fd = self->efd;
+    self->efd = -1;
+    nn_closefd (fd);
+}
+
+void nn_efd_stop (struct nn_efd *self)
+{
+    nn_efd_signal (self);
 }
 
 nn_fd nn_efd_getfd (struct nn_efd *self)
@@ -61,18 +69,25 @@ void nn_efd_signal (struct nn_efd *self)
 {
     const uint64_t one = 1;
     ssize_t nbytes;
+    int fd = self->efd;
 
-    nbytes = write (self->efd, &one, sizeof (one));
+    if (nn_slow (fd < 0))
+        return;
+
+    nbytes = write (fd, &one, sizeof (one));
     errno_assert (nbytes == sizeof (one));
 }
 
 void nn_efd_unsignal (struct nn_efd *self)
 {
     uint64_t count;
+    int fd = self->efd;
+
+    if (nn_slow (fd < 0))
+        return;
 
     /*  Extract all the signals from the eventfd. */
-    ssize_t sz = read (self->efd, &count, sizeof (count));
+    ssize_t sz = read (fd, &count, sizeof (count));
     errno_assert (sz >= 0);
     nn_assert (sz == sizeof (count));
 }
-

--- a/src/utils/efd_pipe.inc
+++ b/src/utils/efd_pipe.inc
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
+    Copyright 2015 Garrett D'Amore <garrett@damore.org>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -67,8 +68,22 @@ int nn_efd_init (struct nn_efd *self)
 
 void nn_efd_term (struct nn_efd *self)
 {
-    nn_closefd (self->r);
-    nn_closefd (self->w);
+    /*  Close the read side first. */
+    int fd = self->r;
+    self->r = -1;
+    nn_closefd (fd);
+
+    fd = self->w;
+    self->w = -1;
+    nn_closefd (fd);
+}
+
+void nn_efd_stop (struct nn_efd *self)
+{
+    /*  Close the write side, which wakes up pollers with POLLHUP. */
+    int fd = self->w;
+    self->w = -1;
+    nn_closefd (fd);
 }
 
 nn_fd nn_efd_getfd (struct nn_efd *self)
@@ -80,7 +95,10 @@ void nn_efd_signal (struct nn_efd *self)
 {
     ssize_t nbytes;
     char c = 101;
+    int fd = self->w;
 
+    if (nn_slow (fd < 0))
+        return;
     nbytes = write (self->w, &c, 1);
     errno_assert (nbytes != -1);
     nn_assert (nbytes == 1);
@@ -92,7 +110,10 @@ void nn_efd_unsignal (struct nn_efd *self)
     uint8_t buf [16];
 
     while (1) {
-        nbytes = read (self->r, buf, sizeof (buf));
+        int fd = self->r;
+        if (nn_slow (fd < 0))
+            return;
+        nbytes = read (fd, buf, sizeof (buf));
         if (nbytes < 0 && errno == EAGAIN)
             nbytes = 0;
         errno_assert (nbytes >= 0);

--- a/src/utils/efd_socketpair.inc
+++ b/src/utils/efd_socketpair.inc
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
+    Copyright 2015 Garrett D'Amore <garrett@damore.org>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -63,10 +64,21 @@ int nn_efd_init (struct nn_efd *self)
     return 0;
 }
 
+void nn_efd_stop (struct nn_efd *self)
+{
+    int fd = self->w;
+    self->w = -1;
+    nn_closefd (fd);
+}
+
 void nn_efd_term (struct nn_efd *self)
 {
-    nn_closefd (self->r);
-    nn_closefd (self->w);
+    int fd = self->r;
+    self->r = -1;
+    nn_closefd (fd);
+    fd = self->w;
+    self->w = -1;
+    nn_closefd (fd);
 }
 
 nn_fd nn_efd_getfd (struct nn_efd *self)
@@ -78,11 +90,14 @@ void nn_efd_signal (struct nn_efd *self)
 {
     ssize_t nbytes;
     char c = 101;
+    int fd = self->w;
 
+    if (nn_slow (fd < 0))
+        return;
 #if defined MSG_NOSIGNAL
-    nbytes = send (self->w, &c, 1, MSG_NOSIGNAL);
+    nbytes = send (fd, &c, 1, MSG_NOSIGNAL);
 #else
-    nbytes = send (self->w, &c, 1, 0);
+    nbytes = send (fd, &c, 1, 0);
 #endif
     errno_assert (nbytes != -1);
     nn_assert (nbytes == 1);
@@ -94,6 +109,9 @@ void nn_efd_unsignal (struct nn_efd *self)
     uint8_t buf [16];
 
     while (1) {
+        int fd = self->r;
+        if (nn_slow (fd < 0))
+            return;
         nbytes = recv (self->r, buf, sizeof (buf), 0);
         if (nbytes < 0 && errno == EAGAIN)
             nbytes = 0;
@@ -102,4 +120,3 @@ void nn_efd_unsignal (struct nn_efd *self)
             break;
     }
 }
-

--- a/src/utils/efd_win.inc
+++ b/src/utils/efd_win.inc
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
+    Copyright 2015 Garrett D'Amore <garrett@damore.org>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -201,14 +202,35 @@ wsafail3:
     return -rc;
 }
 
+void nn_efd_stop (struct nn_efd *self)
+{
+    int rc;
+    SOCKET s = self->w;
+    self->w = INVALID_SOCKET;
+
+    if (s != INVALID_SOCKET) {
+        rc = closesocket (s);
+        wsa_assert (rc != INVALID_SOCKET);
+    }
+}
+
 void nn_efd_term (struct nn_efd *self)
 {
     int rc;
+    SOCKET s;
 
-    rc = closesocket (self->w);
-    wsa_assert (rc != INVALID_SOCKET);
-    rc = closesocket (self->r);
-    wsa_assert (rc != INVALID_SOCKET);
+    s = self->r;
+    self->r = INVALID_SOCKET;
+    if (s != INVALID_SOCKET) {
+        rc = closesocket (s);
+        wsa_assert (rc != INVALID_SOCKET);
+    }
+    s = self->w;
+    self->w = INVALID_SOCKET;
+    if (s != INVALID_SOCKET) {
+       rc = closesocket (s);
+       wsa_assert (rc != INVALID_SOCKET);
+    }
 }
 
 nn_fd nn_efd_getfd (struct nn_efd *self)
@@ -220,10 +242,13 @@ void nn_efd_signal (struct nn_efd *self)
 {
     int rc;
     unsigned char c = 0xec;
+    SOCKET s = self->w;
 
-    rc = send (self->w, (char*) &c, 1, 0);
-    wsa_assert (rc != SOCKET_ERROR);
-    nn_assert (rc == 1);
+    if (nn_fast (s != INVALID_SOCKET)) {
+        rc = send (s, (char*) &c, 1, 0);
+        wsa_assert (rc != SOCKET_ERROR);
+        nn_assert (rc == 1);
+    }
 }
 
 void nn_efd_unsignal (struct nn_efd *self)
@@ -232,7 +257,10 @@ void nn_efd_unsignal (struct nn_efd *self)
     uint8_t buf [16];
 
     while (1) {
-        rc = recv (self->r, (char*) buf, sizeof (buf), 0);
+        SOCKET s = self->r;
+        if (nn_slow (s == INVALID_SOCKET))
+            break;
+        rc = recv (s, (char*) buf, sizeof (buf), 0);
         if (rc == SOCKET_ERROR && WSAGetLastError () == WSAEWOULDBLOCK)
             rc = 0;
         wsa_assert (rc != SOCKET_ERROR);

--- a/src/utils/err.c
+++ b/src/utils/err.c
@@ -160,6 +160,8 @@ int nn_err_wsa_to_posix (int wsaerr)
         return ECONNABORTED;
     case WSAECONNRESET:
         return ECONNRESET;
+    case WSAENOTSOCK:
+        return ENOTSOCK;
     case ERROR_BROKEN_PIPE:
         return ECONNRESET;
     case WSAESOCKTNOSUPPORT:

--- a/tests/async_shutdown.c
+++ b/tests/async_shutdown.c
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012 Martin Sustrik  All rights reserved.
+    Copyright (c) 2015 Jack R. Dunaway.  All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -22,53 +23,54 @@
 
 #include "../src/nn.h"
 #include "../src/pair.h"
+#include "../src/pubsub.h"
+#include "../src/pipeline.h"
+#include "../src/tcp.h"
 
-#include "../src/utils/thread.c"
 #include "testutil.h"
+#include "../src/utils/attr.h"
+#include "../src/utils/thread.c"
+#include "../src/utils/atomic.c"
 
-static void worker (NN_UNUSED void *arg)
+/*  Test condition of closing sockets that are blocking in another thread. */
+
+#define TEST_LOOPS 10
+#define SOCKET_ADDRESS "tcp://127.0.0.1:5557"
+
+struct nn_atomic active;
+
+static void routine (NN_UNUSED void *arg)
 {
-    int rc;
     int s;
-    char buf [3];
+    int rc;
+    int msg;
 
-    /*  Test socket. */
-    s = test_socket (AF_SP, NN_PAIR);
+    nn_assert (arg);
 
-    /*  Launch blocking function to check that it will be unblocked once
-        nn_term() is called from the main thread. */
-    rc = nn_recv (s, buf, sizeof (buf), 0);
-    nn_assert (rc == -1 && nn_errno () == ETERM);
+    s = *((int *) arg);
 
-    /*  Check that all subsequent operations fail in synchronous manner. */
-    rc = nn_recv (s, buf, sizeof (buf), 0);
-    nn_assert (rc == -1 && nn_errno () == ETERM);
-    test_close (s);
+    /*  We don't expect to actually receive a message here;
+        therefore, the datatype of 'msg' is irrelevant. */
+    rc = nn_recv (s, &msg, sizeof(msg), 0);
+
+    errno_assert (nn_errno () == EBADF);
 }
 
 int main ()
 {
-    int rc;
-    int s;
+    int sb;
+    int i;
     struct nn_thread thread;
 
-    /*  Close the socket with no associated endpoints. */
-    s = test_socket (AF_SP, NN_PAIR);
-    test_close (s);
-
-    /*  Test nn_term() before nn_close(). */
-    nn_thread_init (&thread, worker, NULL);
-    nn_sleep (100);
-    nn_term ();
-
-    /*  Check that it's not possible to create new sockets after nn_term(). */
-    rc = nn_socket (AF_SP, NN_PAIR);
-    nn_assert (rc == -1);
-    errno_assert (nn_errno () == ETERM);
-
-    /*  Wait till worker thread terminates. */
-    nn_thread_term (&thread);
+    for (i = 0; i != TEST_LOOPS; ++i) {
+        sb = test_socket (AF_SP, NN_PULL);
+        test_bind (sb, SOCKET_ADDRESS);
+        nn_sleep (100);
+        nn_thread_init (&thread, routine, &sb);
+        nn_sleep (100);
+        test_close (sb);
+        nn_thread_term (&thread);
+    }
 
     return 0;
 }
-

--- a/tests/device.c
+++ b/tests/device.c
@@ -51,7 +51,7 @@ void device1 (NN_UNUSED void *arg)
 
     /*  Run the device. */
     rc = nn_device (deva, devb);
-    nn_assert (rc < 0 && nn_errno () == ETERM);
+    nn_assert (rc < 0 && (nn_errno () == ETERM || nn_errno () == EBADF));
 
     /*  Clean up. */
     test_close (devb);

--- a/tests/device4.c
+++ b/tests/device4.c
@@ -47,7 +47,7 @@ void device4 (NN_UNUSED void *arg)
 
     /*  Run the device. */
     rc = nn_device (devf, devg);
-    nn_assert (rc < 0 && nn_errno () == ETERM);
+    nn_assert (rc < 0 && (nn_errno () == ETERM || nn_errno () == EBADF));
 
     /*  Clean up. */
     test_close (devg);

--- a/tests/testutil.h
+++ b/tests/testutil.h
@@ -117,7 +117,7 @@ static void NN_UNUSED test_close_impl (char *file, int line, int sock)
     int rc;
 
     rc = nn_close (sock);
-    if (rc != 0) {
+    if ((rc != 0) && (errno != EBADF && errno != ETERM)) {
         fprintf (stderr, "Failed to close socket: %s [%d] (%s:%d)\n",
             nn_err_strerror (errno),
             (int) errno, file, line);


### PR DESCRIPTION
fixes #524 Sockets array is not thread-safe
fixes #519 How to close a device without closing everything.
fixes #523 Want a test to verify nn_close() aborts nn_recv()

Portions contributed by Jack R. Dunaway <jack@wirebirdlabs.com>.