### PR TITLE
Fix compilation with gcc 5.2.0 (mingw)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     add_definitions (-D_CRT_SECURE_NO_WARNINGS)
 
     if (MINGW)
-        add_definitions (-DNN_HAVE_MINGW -DNN_HAVE_STDINT -D_WIN32_WINNT=0x0600)
+        add_definitions (-DNN_HAVE_MINGW -D_POSIX_C_SOURCE -DNN_HAVE_STDINT -D_WIN32_WINNT=0x0600)
     endif ()
 else ()
     message (FATAL_ERROR "ERROR: CMake build system is intended only to generate MSVC solution files.\nUse autotools build system for any other purpose." )


### PR DESCRIPTION
`_POSIX_C_SOURCE` needs to be defined with gcc 5.2.0 (mingw) to have `gmtime_r`.

fix #530 
