### PR TITLE
fixes #536 nn_worker_routine call nn_poller_set_out occur assert

### DIFF
--- a/src/aio/poller_epoll.inc
+++ b/src/aio/poller_epoll.inc
@@ -70,18 +70,15 @@ void nn_poller_add (struct nn_poller *self, int fd,
     memset (&ev, 0, sizeof (ev));
     ev.events = 0;
     ev.data.ptr = (void*) hndl;
-    rc = epoll_ctl (self->ep, EPOLL_CTL_ADD, fd, &ev);
-    errno_assert (rc == 0);
+    epoll_ctl (self->ep, EPOLL_CTL_ADD, fd, &ev);
 }
 
 void nn_poller_rm (struct nn_poller *self, struct nn_poller_hndl *hndl)
 {
-    int rc;
     int i;
 
     /*  Remove the file descriptor from the pollset. */
-    rc = epoll_ctl (self->ep, EPOLL_CTL_DEL, hndl->fd, NULL);
-    errno_assert (rc == 0);
+    epoll_ctl (self->ep, EPOLL_CTL_DEL, hndl->fd, NULL);
 
     /*  Invalidate any subsequent events on this file descriptor. */
     for (i = self->index; i != self->nevents; ++i)
@@ -91,7 +88,6 @@ void nn_poller_rm (struct nn_poller *self, struct nn_poller_hndl *hndl)
 
 void nn_poller_set_in (struct nn_poller *self, struct nn_poller_hndl *hndl)
 {
-    int rc;
     struct epoll_event ev;
 
     /*  If already polling for IN, do nothing. */
@@ -103,13 +99,11 @@ void nn_poller_set_in (struct nn_poller *self, struct nn_poller_hndl *hndl)
     memset (&ev, 0, sizeof (ev));
     ev.events = hndl->events;
     ev.data.ptr = (void*) hndl;
-    rc = epoll_ctl (self->ep, EPOLL_CTL_MOD, hndl->fd, &ev);
-    errno_assert (rc == 0);
+    epoll_ctl (self->ep, EPOLL_CTL_MOD, hndl->fd, &ev);
 }
 
 void nn_poller_reset_in (struct nn_poller *self, struct nn_poller_hndl *hndl)
 {
-    int rc;
     int i;
     struct epoll_event ev;
 
@@ -122,8 +116,7 @@ void nn_poller_reset_in (struct nn_poller *self, struct nn_poller_hndl *hndl)
     memset (&ev, 0, sizeof (ev));
     ev.events = hndl->events;
     ev.data.ptr = (void*) hndl;
-    rc = epoll_ctl (self->ep, EPOLL_CTL_MOD, hndl->fd, &ev);
-    errno_assert (rc == 0);
+    epoll_ctl (self->ep, EPOLL_CTL_MOD, hndl->fd, &ev);
 
     /*  Invalidate any subsequent IN events on this file descriptor. */
     for (i = self->index; i != self->nevents; ++i)
@@ -133,8 +126,8 @@ void nn_poller_reset_in (struct nn_poller *self, struct nn_poller_hndl *hndl)
 
 void nn_poller_set_out (struct nn_poller *self, struct nn_poller_hndl *hndl)
 {
-    int rc;
     struct epoll_event ev;
+    int fd = hndl->fd;
 
     /*  If already polling for OUT, do nothing. */
     if (nn_slow (hndl->events & EPOLLOUT))
@@ -145,13 +138,11 @@ void nn_poller_set_out (struct nn_poller *self, struct nn_poller_hndl *hndl)
     memset (&ev, 0, sizeof (ev));
     ev.events = hndl->events;
     ev.data.ptr = (void*) hndl;
-    rc = epoll_ctl (self->ep, EPOLL_CTL_MOD, hndl->fd, &ev);
-    errno_assert (rc == 0);
+    epoll_ctl (self->ep, EPOLL_CTL_MOD, fd, &ev);
 }
 
 void nn_poller_reset_out (struct nn_poller *self, struct nn_poller_hndl *hndl)
 {
-    int rc;
     int i;
     struct epoll_event ev;
 
@@ -164,8 +155,7 @@ void nn_poller_reset_out (struct nn_poller *self, struct nn_poller_hndl *hndl)
     memset (&ev, 0, sizeof (ev));
     ev.events = hndl->events;
     ev.data.ptr = (void*) hndl;
-    rc = epoll_ctl (self->ep, EPOLL_CTL_MOD, hndl->fd, &ev);
-    errno_assert (rc == 0);
+    epoll_ctl (self->ep, EPOLL_CTL_MOD, hndl->fd, &ev);
 
     /*  Invalidate any subsequent OUT events on this file descriptor. */
     for (i = self->index; i != self->nevents; ++i)

--- a/src/aio/poller_kqueue.inc
+++ b/src/aio/poller_kqueue.inc
@@ -69,14 +69,12 @@ void nn_poller_rm (struct nn_poller *self, struct nn_poller_hndl *hndl)
 
     if (hndl->events & NN_POLLER_EVENT_IN) {
         EV_SET (&ev, hndl->fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
-        rc = kevent (self->kq, &ev, 1, NULL, 0, NULL);
-        errno_assert (rc != -1);
+        kevent (self->kq, &ev, 1, NULL, 0, NULL);
     }
 
     if (hndl->events & NN_POLLER_EVENT_OUT) {
         EV_SET (&ev, hndl->fd, EVFILT_WRITE, EV_DELETE, 0, 0, 0);
-        rc = kevent (self->kq, &ev, 1, NULL, 0, NULL);
-        errno_assert (rc != -1);
+        kevent (self->kq, &ev, 1, NULL, 0, NULL);
     }
 
     /*  Invalidate any subsequent events on this file descriptor. */
@@ -89,13 +87,14 @@ void nn_poller_set_in (struct nn_poller *self, struct nn_poller_hndl *hndl)
 {
     int rc;
     struct kevent ev;
+    int fd = hndl->fd;
 
     if (!(hndl->events & NN_POLLER_EVENT_IN)) {
         EV_SET (&ev, hndl->fd, EVFILT_READ, EV_ADD, 0, 0,
             (nn_poller_udata) hndl);
         rc = kevent (self->kq, &ev, 1, NULL, 0, NULL);
-        errno_assert (rc != -1);
-        hndl->events |= NN_POLLER_EVENT_IN;
+        if (rc != -1)
+            hndl->events |= NN_POLLER_EVENT_IN;
     }
 }
 
@@ -108,7 +107,6 @@ void nn_poller_reset_in (struct nn_poller *self, struct nn_poller_hndl *hndl)
     if (hndl->events & NN_POLLER_EVENT_IN) {
         EV_SET (&ev, hndl->fd, EVFILT_READ, EV_DELETE, 0, 0, 0);
         rc = kevent (self->kq, &ev, 1, NULL, 0, NULL);
-        errno_assert (rc != -1);
         hndl->events &= ~NN_POLLER_EVENT_IN;
     }
 
@@ -123,13 +121,13 @@ void nn_poller_set_out (struct nn_poller *self, struct nn_poller_hndl *hndl)
 {
     int rc;
     struct kevent ev;
+    int fd = hndl->fd;
 
     if (!(hndl->events & NN_POLLER_EVENT_OUT)) {
-        EV_SET (&ev, hndl->fd, EVFILT_WRITE, EV_ADD, 0, 0,
-            (nn_poller_udata) hndl);
+        EV_SET (&ev, fd, EVFILT_WRITE, EV_ADD, 0, 0, (nn_poller_udata) hndl);
         rc = kevent (self->kq, &ev, 1, NULL, 0, NULL);
-        errno_assert (rc != -1);
-        hndl->events |= NN_POLLER_EVENT_OUT;
+        if (rc != -1)
+            hndl->events |= NN_POLLER_EVENT_OUT;
     }
 }
 
@@ -138,12 +136,14 @@ void nn_poller_reset_out (struct nn_poller *self, struct nn_poller_hndl *hndl)
     int rc;
     struct kevent ev;
     int i;
+    int fd = hndl->fd;
 
     if (hndl->events & NN_POLLER_EVENT_OUT) {
-        EV_SET (&ev, hndl->fd, EVFILT_WRITE, EV_DELETE, 0, 0, 0);
+        EV_SET (&ev, fd, EVFILT_WRITE, EV_DELETE, 0, 0, 0);
         rc = kevent (self->kq, &ev, 1, NULL, 0, NULL);
-        errno_assert (rc != -1);
-        hndl->events &= ~NN_POLLER_EVENT_OUT;
+        if (rc != -1) {
+            hndl->events &= ~NN_POLLER_EVENT_OUT;
+        }
     }
 
     /*  Invalidate any subsequent OUT events on this file descriptor. */


### PR DESCRIPTION
fixes #230 Bad file descriptor [9] (src/aio/poller_epoll.inc:107)

Basically, we have to accept that the fd can be closed (EBADFD) by a concurrent worker_term call.