### PR TITLE
Providing test to demonstrate hang in nn_close on websocket transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ add_libnanomsg_test (zerocopy)
 add_libnanomsg_test (shutdown)
 add_libnanomsg_test (cmsg)
 add_libnanomsg_test (bug328)
+add_libnanomsg_test (ws_async_shutdown)
 
 #  Build the performance tests.
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -507,7 +507,8 @@ FEATURE_TESTS = \
     tests/zerocopy \
     tests/shutdown \
     tests/cmsg \
-    tests/bug328
+    tests/bug328 \
+    tests/ws_async_shutdown
 
 EXTRA_DIST += tests/testutil.h
 

--- a/tests/ws_async_shutdown.c
+++ b/tests/ws_async_shutdown.c
@@ -63,6 +63,8 @@ static void routine (NN_UNUSED void *arg)
 
 int main ()
 {
+    int i;
+    int j;
     int s;
     int sb;
     int rcvtimeo = 10;
@@ -70,14 +72,14 @@ int main ()
     int sockets [TEST_THREADS];
     struct nn_thread threads [TEST_THREADS];
 
-    for (int i = 0; i != TEST_LOOPS; ++i) {
+    for (i = 0; i != TEST_LOOPS; ++i) {
         
         sb = test_socket (AF_SP, NN_PUB);
         test_bind (sb, SOCKET_ADDRESS);
         test_setsockopt (sb, NN_SOL_SOCKET, NN_SNDTIMEO,
             &sndtimeo, sizeof (sndtimeo));
 
-        for (int j = 0; j < TEST_THREADS; j++){
+        for (j = 0; j < TEST_THREADS; j++){
             s = test_socket (AF_SP, NN_SUB);
             test_setsockopt (s, NN_SOL_SOCKET, NN_RCVTIMEO,
                 &rcvtimeo, sizeof (rcvtimeo));
@@ -92,7 +94,7 @@ int main ()
 
         test_send (sb, "");
         
-        for (int j = 0; j < TEST_THREADS; j++) {
+        for (j = 0; j < TEST_THREADS; j++) {
             test_close (sockets [j]);
             nn_thread_term (&threads [j]);
         }

--- a/tests/ws_async_shutdown.c
+++ b/tests/ws_async_shutdown.c
@@ -1,0 +1,104 @@
+/*
+    Copyright (c) 2012 Martin Sustrik  All rights reserved.
+    Copyright (c) 2015 Jack R. Dunaway. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom
+    the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#include "../src/nn.h"
+#include "../src/pubsub.h"
+
+#include "testutil.h"
+#include "../src/utils/thread.c"
+
+/*  Test condition of closing sockets that are blocking in another thread. */
+
+#define SOCKET_ADDRESS "ws://127.0.0.1:5558"
+#define TEST_LOOPS 10
+#define TEST_THREADS 10
+
+static void routine (NN_UNUSED void *arg)
+{
+    int s;
+    int rc;
+    char msg[1];
+
+    nn_assert (arg);
+
+    s = *(int *)arg;
+    
+    while (1) {
+        rc = nn_recv (s, &msg, sizeof(msg), 0);
+        if (rc == 0) {
+            continue;
+        }
+
+        nn_assert (rc == -1);
+
+        /*  A timeout is OK since PUB/SUB is lossy. */
+        if (nn_errno () == ETIMEDOUT) {
+            continue;
+        }
+        break;
+    }
+    /*  Socket is expected to be closed by caller.  */
+    errno_assert (nn_errno () == EBADF);
+}
+
+int main ()
+{
+    int s;
+    int sb;
+    int rcvtimeo = 10;
+    int sndtimeo = 0;
+    int sockets [TEST_THREADS];
+    struct nn_thread threads [TEST_THREADS];
+
+    for (int i = 0; i != TEST_LOOPS; ++i) {
+        
+        sb = test_socket (AF_SP, NN_PUB);
+        test_bind (sb, SOCKET_ADDRESS);
+        test_setsockopt (sb, NN_SOL_SOCKET, NN_SNDTIMEO,
+            &sndtimeo, sizeof (sndtimeo));
+
+        for (int j = 0; j < TEST_THREADS; j++){
+            s = test_socket (AF_SP, NN_SUB);
+            test_setsockopt (s, NN_SOL_SOCKET, NN_RCVTIMEO,
+                &rcvtimeo, sizeof (rcvtimeo));
+            test_setsockopt (s, NN_SUB, NN_SUB_SUBSCRIBE, "", 0);
+            test_connect (s, SOCKET_ADDRESS);
+            sockets [j] = s;
+            nn_thread_init (&threads [j], routine, &sockets [j]);
+        }
+
+        /*  Allow all threads a bit of time to connect. */
+        nn_sleep (100);
+
+        test_send (sb, "");
+        
+        for (int j = 0; j < TEST_THREADS; j++) {
+            test_close (sockets [j]);
+            nn_thread_term (&threads [j]);
+        }
+
+        test_close (sb);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This test demonstrates an occasional hang (at least on Windows) on line 100 when the PUB socket is closed. Creating PR in order to kick off automated builds on other platforms to see if they fail here as well, or if it is limited to just Windows.

This only *appears* to hang on the WebSocket transport. This could be just a problem with the WebSocket transport implementation (the most likely scenario), or it could be because the WebSocket transport incidentally requires more time to connect and perhaps disconnect sockets, as compared to say TCP, and is thus more likely to trigger a race condition.