### PR TITLE
fixes #554

### DIFF
--- a/src/core/global.c
+++ b/src/core/global.c
@@ -578,12 +578,12 @@ int nn_close (int s)
         This is done with the glock held to ensure that two instances
         of nn_close can't access the same socket. */
     nn_sock_stop (sock);
-    nn_glock_unlock ();
 
     /*  We have to drop both the hold we just acquired, as well as
         the original hold, in order for nn_sock_term to complete. */
     nn_sock_rele (sock);
     nn_sock_rele (sock);
+    nn_glock_unlock ();
 
     /*  Now clean up.  The termination routine below will block until
         all other consumers of the socket have dropped their holds, and


### PR DESCRIPTION
Fingers crossed, this fixes #554 by releasing holds within the global lock. Even if not a full fix, it's anecdotally been helping with shutdown race conditions, especially in the WebSocket transport in and around failing connections with the proper RFC 6455 Close Handshake.

Although we typically strive to take things out of locks rather than put them in, these operations should be extremely fast, adding little penalty.