### PR TITLE
Added missing errno value to nn_close(3) man page.

### DIFF
--- a/doc/nn_close.txt
+++ b/doc/nn_close.txt
@@ -34,6 +34,8 @@ The provided socket is invalid.
 *EINTR*::
 Operation was interrupted by a signal. The socket is not fully closed yet.
 Operation can be re-started by calling _nn_close()_ again.
+*ETERM*::
+The library is not initialized or is terminating.
 
 
 EXAMPLE


### PR DESCRIPTION
`nn_close` seems to set errno to ETERM if the library has not yet been initialized, or if no open sockets are remaining.

I am unsure whether the function should set errno to EBADF instead (since at both of these points there is no way any integer could be a valid socket) or if the current behaviour should be documented.

In doubt, this PR fixes the man page for `nn_close(3)` to mention ETERM in the list of possible errno values.