### PR TITLE
fixes #582 Added optional at-fork strategies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - mkdir build
   - cd build
   # Perform CMake backend generation, build, and test
-  - cmake ..
+  - cmake -DNN_FORK_STRATEGY=RESET ..
   - cmake --build . -- -j4
   - ctest --output-on-failure -C Debug -j4
 deploy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,8 @@ if (NN_TESTS)
     # Platform-specific tests
     if (WIN32)
         add_libnanomsg_test (win_sec_attr 5)
+    else ()
+        add_libnanomsg_test (fork 5)
     endif()
 
     #  Build the performance tests.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ option (NN_ENABLE_GETADDRINFO_A "Enable/disable use of getaddrinfo_a in place of
 option (NN_TESTS "Build and run nanomsg tests" ON)
 option (NN_TOOLS "Build nanomsg tools" ON)
 option (NN_ENABLE_NANOCAT "Enable building nanocat utility." ${NN_TOOLS})
+option (NN_FORK_STRATEGY "Use a specific fork strategy (NONE or RESET)" NONE)
 
 #  Platform checks.
 
@@ -196,6 +197,10 @@ if (NN_HAVE_GCC_ATOMIC_BUILTINS)
     add_definitions (-DNN_HAVE_GCC_ATOMIC_BUILTINS)
 endif ()
 
+if (NN_FORK_STRATEGY STREQUAL "RESET")
+    add_definitions (-DNN_RESET_AFTER_FORK)
+endif ()
+
 add_subdirectory (src)
 
 #  Build the tools
@@ -270,7 +275,9 @@ if (NN_TESTS)
     # Platform-specific tests
     if (WIN32)
         add_libnanomsg_test (win_sec_attr 5)
-    else ()
+    endif ()
+
+    if (NOT NN_FORK_STRATEGY STREQUAL "NONE")
         add_libnanomsg_test (fork 5)
     endif()
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -123,6 +123,8 @@ NANOMSG_UTILS = \
     src/utils/err.c \
     src/utils/fast.h \
     src/utils/fd.h \
+    src/utils/fork.h \
+    src/utils/fork.c \
     src/utils/glock.h \
     src/utils/glock.c \
     src/utils/hash.h \
@@ -489,6 +491,7 @@ FEATURE_TESTS = \
     tests/zerocopy \
     tests/shutdown \
     tests/stats \
+    tests/fork \
     tests/cmsg \
     tests/bug328
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -108,6 +108,8 @@ NANOMSG_UTILS = \
     src/utils/clock.c \
     src/utils/closefd.h \
     src/utils/closefd.c \
+    src/utils/cond.h \
+    src/utils/cond.c \
     src/utils/cont.h \
     src/utils/efd.h \
     src/utils/efd.c \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,8 @@ set (NN_SOURCES
     utils/closefd.h
     utils/closefd.c
     utils/cont.h
+    utils/cond.c
+    utils/cond.h
     utils/efd.h
     utils/efd.c
     utils/err.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,8 +84,6 @@ set (NN_SOURCES
     utils/err.c
     utils/fast.h
     utils/fd.h
-    utils/fork.c
-    utils/fork.h
     utils/glock.h
     utils/glock.c
     utils/hash.h
@@ -259,6 +257,8 @@ elseif (UNIX)
         aio/usock_posix.inc
         aio/worker_posix.h
         aio/worker_posix.inc
+        utils/fork.c
+        utils/fork.h
         utils/thread_posix.h
         utils/thread_posix.inc
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,8 @@ set (NN_SOURCES
     utils/err.c
     utils/fast.h
     utils/fd.h
+    utils/fork.c
+    utils/fork.h
     utils/glock.h
     utils/glock.c
     utils/hash.h

--- a/src/aio/poller.c
+++ b/src/aio/poller.c
@@ -1,6 +1,7 @@
 /*
     Copyright (c) 2012 Martin Sustrik  All rights reserved.
     Copyright (c) 2015-2016 Jack R. Dunaway.  All rights reserved.
+    Copyright 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -31,4 +32,54 @@
     #include "poller_poll.inc"
 #else
     #error
+#endif
+
+#if !defined NN_USE_POLL && (defined NN_USE_EPOLL || defined NN_USE_KQUEUE)
+#include "../utils/cont.h"
+
+void nn_poller_revive (struct nn_poller *self)
+{
+    struct nn_list fds;
+    struct nn_list_item *it, *next;
+    struct nn_poller_hndl *hndl;
+    uint32_t events;
+    int rc;
+
+    /*  Copy the file descriptor list locally. */
+    memcpy (&fds, &self->fds, sizeof (struct nn_list));
+    nn_list_init (&self->fds);
+
+    /*  Recreate the poller  */
+    rc = nn_poller_reinit (self);
+    errnum_assert (rc == 0, rc);
+
+    /*  Add all file descriptors back  */
+    for (it = nn_list_begin (&fds); it != nn_list_end (&fds);) {
+        next = nn_list_erase (&fds, it);
+        nn_list_item_term (it);
+
+        hndl = nn_cont (it, struct nn_poller_hndl, item);
+
+        events = hndl->events;
+        nn_poller_add (self, hndl->fd, hndl);
+
+#ifdef NN_USE_EPOLL
+        if (events & EPOLLOUT) {
+#else
+        if (events & NN_POLLER_EVENT_OUT) {
+#endif
+            nn_poller_set_out (self, hndl);
+        }
+
+#ifdef NN_USE_EPOLL
+        if (events & EPOLLIN) {
+#else
+        if (events & NN_POLLER_EVENT_IN) {
+#endif
+            nn_poller_set_in (self, hndl);
+        }
+
+        it = next;
+    }
+}
 #endif

--- a/src/aio/poller.h
+++ b/src/aio/poller.h
@@ -1,6 +1,7 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
     Copyright (c) 2015-2016 Jack R. Dunaway.  All rights reserved.
+    Copyright 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -50,5 +51,8 @@ void nn_poller_reset_out (struct nn_poller *self, struct nn_poller_hndl *hndl);
 int nn_poller_wait (struct nn_poller *self, int timeout);
 int nn_poller_event (struct nn_poller *self, int *event,
     struct nn_poller_hndl **hndl);
+
+void nn_poller_revive (struct nn_poller *self);
+int nn_poller_reinit (struct nn_poller *self);
 
 #endif

--- a/src/aio/poller_epoll.h
+++ b/src/aio/poller_epoll.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -28,9 +29,13 @@
 
 #define NN_POLLER_MAX_EVENTS 32
 
+#include "../utils/list.h"
+#include "../utils/mutex.h"
+
 struct nn_poller_hndl {
     int fd;
     uint32_t events;
+    struct nn_list_item item;
 };
 
 struct nn_poller {
@@ -46,5 +51,7 @@ struct nn_poller {
 
     /*  Events being processed at the moment. */
     struct epoll_event events [NN_POLLER_MAX_EVENTS];
-};
 
+    struct nn_list fds;
+    struct nn_mutex sync;
+};

--- a/src/aio/poller_epoll.inc
+++ b/src/aio/poller_epoll.inc
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012 Martin Sustrik  All rights reserved.
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -23,6 +24,7 @@
 #include "../utils/fast.h"
 #include "../utils/err.h"
 #include "../utils/closefd.h"
+#include "../utils/cont.h"
 
 #include <string.h>
 #include <unistd.h>
@@ -50,12 +52,16 @@ int nn_poller_init (struct nn_poller *self)
     self->nevents = 0;
     self->index = 0;
 
+    nn_mutex_init (&self->sync);
+    nn_list_init (&self->fds);
+
     return 0;
 }
 
 void nn_poller_term (struct nn_poller *self)
 {
     nn_closefd (self->ep);
+    nn_mutex_term (&self->sync);
 }
 
 void nn_poller_add (struct nn_poller *self, int fd,
@@ -67,10 +73,16 @@ void nn_poller_add (struct nn_poller *self, int fd,
     /*  Initialise the handle and add the file descriptor to the pollset. */
     hndl->fd = fd;
     hndl->events = 0;
+    nn_list_item_init (&hndl->item);
+
     memset (&ev, 0, sizeof (ev));
     ev.events = 0;
     ev.data.ptr = (void*) hndl;
     epoll_ctl (self->ep, EPOLL_CTL_ADD, fd, &ev);
+
+    nn_mutex_lock (&self->sync);
+    nn_list_insert (&self->fds, &hndl->item, nn_list_end(&self->fds));
+    nn_mutex_unlock (&self->sync);
 }
 
 void nn_poller_rm (struct nn_poller *self, struct nn_poller_hndl *hndl)
@@ -84,6 +96,10 @@ void nn_poller_rm (struct nn_poller *self, struct nn_poller_hndl *hndl)
     for (i = self->index; i != self->nevents; ++i)
         if (self->events [i].data.ptr == hndl)
             self->events [i].events = 0;
+
+    nn_mutex_lock (&self->sync);
+    nn_list_erase (&self->fds, &hndl->item);
+    nn_mutex_unlock (&self->sync);
 }
 
 void nn_poller_set_in (struct nn_poller *self, struct nn_poller_hndl *hndl)
@@ -217,3 +233,8 @@ int nn_poller_event (struct nn_poller *self, int *event,
     }
 }
 
+int nn_poller_reinit (struct nn_poller *self)
+{
+    nn_poller_term (self);
+    return nn_poller_init (self);
+}

--- a/src/aio/poller_kqueue.h
+++ b/src/aio/poller_kqueue.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -29,9 +30,13 @@
 #define NN_POLLER_EVENT_IN 1
 #define NN_POLLER_EVENT_OUT 2
 
+#include "../utils/list.h"
+#include "../utils/mutex.h"
+
 struct nn_poller_hndl {
     int fd;
     int events;
+    struct nn_list_item item;
 };
 
 struct nn_poller {
@@ -47,5 +52,8 @@ struct nn_poller {
 
     /*  Cached events. */
     struct kevent events [NN_POLLER_MAX_EVENTS];
+
+    struct nn_list fds;
+    struct nn_mutex sync;
 };
 

--- a/src/aio/poller_kqueue.inc
+++ b/src/aio/poller_kqueue.inc
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012 Martin Sustrik  All rights reserved.
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -45,12 +46,16 @@ int nn_poller_init (struct nn_poller *self)
     self->nevents = 0;
     self->index = 0;
 
+    nn_mutex_init (&self->sync);
+    nn_list_init (&self->fds);
+
     return 0;
 }
 
 void nn_poller_term (struct nn_poller *self)
 {
     nn_closefd (self->kq);
+    nn_mutex_term (&self->sync);
 }
 
 void nn_poller_add (NN_UNUSED struct nn_poller *self, int fd,
@@ -59,6 +64,11 @@ void nn_poller_add (NN_UNUSED struct nn_poller *self, int fd,
     /*  Initialise the handle. */
     hndl->fd = fd;
     hndl->events = 0;
+    nn_list_item_init (&hndl->item);
+
+    nn_mutex_lock (&self->sync);
+    nn_list_insert (&self->fds, &hndl->item, nn_list_end(&self->fds));
+    nn_mutex_unlock (&self->sync);
 }
 
 void nn_poller_rm (struct nn_poller *self, struct nn_poller_hndl *hndl)
@@ -81,6 +91,10 @@ void nn_poller_rm (struct nn_poller *self, struct nn_poller_hndl *hndl)
     for (i = self->index; i != self->nevents; ++i)
         if (self->events [i].ident == (unsigned) hndl->fd)
             self->events [i].udata = (nn_poller_udata) NULL;
+
+    nn_mutex_lock (&self->sync);
+    nn_list_erase (&self->fds, &hndl->item);
+    nn_mutex_unlock (&self->sync);
 }
 
 void nn_poller_set_in (struct nn_poller *self, struct nn_poller_hndl *hndl)
@@ -211,3 +225,8 @@ int nn_poller_event (struct nn_poller *self, int *event,
     return 0;
 }
 
+int nn_poller_reinit (struct nn_poller *self)
+{
+    nn_mutex_term (&self->sync);
+    return nn_poller_init (self);
+}

--- a/src/aio/poller_poll.inc
+++ b/src/aio/poller_poll.inc
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012 Martin Sustrik  All rights reserved.
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -198,3 +199,11 @@ int nn_poller_event (struct nn_poller *self, int *event,
     }
 }
 
+int nn_poller_reinit (struct nn_poller *self)
+{
+    return 0;
+}
+
+void nn_poller_revive (struct nn_poller *self)
+{
+}

--- a/src/aio/worker_posix.h
+++ b/src/aio/worker_posix.h
@@ -26,6 +26,7 @@
 #include "../utils/mutex.h"
 #include "../utils/thread.h"
 #include "../utils/efd.h"
+#include "../utils/cond.h"
 
 #include "poller.h"
 
@@ -53,11 +54,19 @@ struct nn_worker {
     struct nn_mutex sync;
     struct nn_queue tasks;
     struct nn_queue_item stop;
+    struct nn_queue_item pause;
     struct nn_efd efd;
     struct nn_poller poller;
     struct nn_poller_hndl efd_hndl;
     struct nn_timerset timerset;
     struct nn_thread thread;
+
+    struct nn_cond resume_cond;
+    struct nn_mutex resume_mutex;
+    struct nn_cond pause_cond;
+    struct nn_mutex pause_mutex;
+    volatile int paused;
+    volatile int resumed;
 };
 
 void nn_worker_add_fd (struct nn_worker *self, int s, struct nn_worker_fd *fd);
@@ -69,3 +78,6 @@ void nn_worker_reset_out (struct nn_worker *self, struct nn_worker_fd *fd);
 
 /* Force clean up without terminating the underlying thread                   */
 void nn_worker_force_cleanup (struct nn_worker *self);
+
+void nn_worker_pause (struct nn_worker *self);
+void nn_worker_resume (struct nn_worker *self);

--- a/src/aio/worker_posix.h
+++ b/src/aio/worker_posix.h
@@ -1,6 +1,7 @@
 /*
     Copyright (c) 2013 Martin Sustrik  All rights reserved.
     Copyright (c) 2013 GoPivotal, Inc.  All rights reserved.
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -65,3 +66,6 @@ void nn_worker_set_in (struct nn_worker *self, struct nn_worker_fd *fd);
 void nn_worker_reset_in (struct nn_worker *self, struct nn_worker_fd *fd);
 void nn_worker_set_out (struct nn_worker *self, struct nn_worker_fd *fd);
 void nn_worker_reset_out (struct nn_worker *self, struct nn_worker_fd *fd);
+
+/* Force clean up without terminating the underlying thread                   */
+void nn_worker_force_cleanup (struct nn_worker *self);

--- a/src/aio/worker_posix.h
+++ b/src/aio/worker_posix.h
@@ -81,3 +81,5 @@ void nn_worker_force_cleanup (struct nn_worker *self);
 
 void nn_worker_pause (struct nn_worker *self);
 void nn_worker_resume (struct nn_worker *self);
+
+void nn_worker_revive (struct nn_worker *self);

--- a/src/aio/worker_posix.inc
+++ b/src/aio/worker_posix.inc
@@ -110,20 +110,32 @@ int nn_worker_init (struct nn_worker *self)
     nn_mutex_init (&self->sync);
     nn_queue_init (&self->tasks);
     nn_queue_item_init (&self->stop);
+    nn_queue_item_init (&self->pause);
     nn_poller_init (&self->poller);
     nn_poller_add (&self->poller, nn_efd_getfd (&self->efd), &self->efd_hndl);
     nn_poller_set_in (&self->poller, &self->efd_hndl);
     nn_timerset_init (&self->timerset);
     nn_thread_init (&self->thread, nn_worker_routine, self);
 
+    self->paused = 0;
+    self->resumed = 0;
+    nn_cond_init (&self->resume_cond);
+    nn_mutex_init (&self->resume_mutex);
+    nn_cond_init (&self->pause_cond);
+    nn_mutex_init (&self->pause_mutex);
+
     return 0;
 }
 
 void nn_worker_force_cleanup (struct nn_worker *self) {
+    /*  Wait till worker thread terminates. */
+    nn_thread_term (&self->thread);
+
     nn_timerset_term (&self->timerset);
     nn_poller_term (&self->poller);
     nn_efd_term (&self->efd);
     nn_queue_item_term (&self->stop);
+    nn_queue_item_term (&self->pause);
     nn_queue_term (&self->tasks);
     nn_mutex_term (&self->sync);
 }
@@ -136,11 +148,56 @@ void nn_worker_term (struct nn_worker *self)
     nn_efd_signal (&self->efd);
     nn_mutex_unlock (&self->sync);
 
-    /*  Wait till worker thread terminates. */
-    nn_thread_term (&self->thread);
-
     /*  Clean up. */
     nn_worker_force_cleanup (self);
+
+    nn_cond_term (&self->resume_cond);
+    nn_cond_term (&self->pause_cond);
+    nn_mutex_term (&self->resume_mutex);
+    nn_mutex_term (&self->pause_mutex);
+}
+
+void nn_worker_pause (struct nn_worker *self)
+{
+    nn_assert (!self->paused);
+
+    nn_mutex_lock (&self->pause_mutex);
+
+    /*  Ask worker thread to pause. */
+    nn_mutex_lock (&self->sync);
+    nn_queue_push (&self->tasks, &self->pause);
+    nn_efd_signal (&self->efd);
+    nn_mutex_unlock (&self->sync);
+
+    /*  Wait until the thread is paused  */
+    while (!self->paused) {
+        nn_cond_wait (&self->pause_cond, &self->pause_mutex);
+    }
+
+    nn_mutex_lock (&self->resume_mutex);
+    nn_mutex_unlock (&self->pause_mutex);
+}
+
+void nn_worker_resume (struct nn_worker *self)
+{
+    nn_assert (self->paused);
+
+    nn_mutex_lock (&self->pause_mutex);
+
+    /*  Let the worker resume  */
+    self->paused = 0;
+    nn_cond_signal (&self->resume_cond);
+    nn_mutex_unlock (&self->resume_mutex);
+
+    /*  Wait until the thread is resumed  */
+    while (!self->resumed) {
+        nn_cond_wait (&self->pause_cond, &self->pause_mutex);
+    }
+    self->resumed = 0;
+
+    nn_mutex_lock (&self->resume_mutex);
+    nn_mutex_unlock (&self->pause_mutex);
+    nn_mutex_unlock (&self->resume_mutex);
 }
 
 void nn_worker_execute (struct nn_worker *self, struct nn_worker_task *task)
@@ -222,6 +279,33 @@ static void nn_worker_routine (void *arg)
                     item = nn_queue_pop (&tasks);
                     if (nn_slow (!item))
                         break;
+
+                    /*  If the worker thread is asked to pause, do so. */
+                    if (nn_slow (item == &self->pause)) {
+
+                        nn_mutex_lock (&self->resume_mutex);
+
+                        /*  Notify the calling thread that the worker paused  */
+                        nn_mutex_lock (&self->pause_mutex);
+                        self->paused = 1;
+                        nn_cond_signal (&self->pause_cond);
+                        nn_mutex_unlock (&self->pause_mutex);
+
+                        /*  Pause until the thread is resumed  */
+                        while (self->paused) {
+                            nn_cond_wait (&self->resume_cond,
+                                          &self->resume_mutex);
+                        }
+
+                        /*  Notify the calling thread that the worker resumed */
+                        nn_mutex_lock (&self->pause_mutex);
+                        self->resumed = 1;
+                        nn_cond_signal (&self->pause_cond);
+                        nn_mutex_unlock (&self->pause_mutex);
+
+                        nn_mutex_unlock (&self->resume_mutex);
+                        continue;
+                    }
 
                     /*  If the worker thread is asked to stop, do so. */
                     if (nn_slow (item == &self->stop)) {

--- a/src/aio/worker_posix.inc
+++ b/src/aio/worker_posix.inc
@@ -31,6 +31,10 @@
 #include "../utils/attr.h"
 #include "../utils/queue.h"
 
+#define NN_STATUS_IDLE 0
+#define NN_STATUS_STOP 1
+#define NN_STATUS_PAUSE 2
+
 /*  Private functions. */
 static void nn_worker_routine (void *arg);
 
@@ -250,6 +254,52 @@ void nn_worker_cancel (struct nn_worker *self, struct nn_worker_task *task)
     nn_mutex_unlock (&self->sync);
 }
 
+static int nn_worker_process_tasks (struct nn_worker *self, struct nn_queue *tasks)
+{
+    struct nn_queue_item *item;
+    struct nn_worker_task *task;
+    int status;
+
+    status = NN_STATUS_IDLE;
+
+    while (1) {
+
+        /*  Next worker task. */
+        item = nn_queue_pop (tasks);
+        if (nn_slow (!item))
+            break;
+
+        /*  If the worker thread is asked to pause, schedule a
+        pause after everything else is processed. */
+        if (nn_slow (item == &self->pause)) {
+            status = NN_STATUS_PAUSE;
+            continue;
+        }
+
+        /*  If the worker thread is asked to stop, do so. */
+        if (nn_slow (item == &self->stop)) {
+            /*  Make sure we remove all the other workers from
+            the queue, because we're not doing anything with
+            them. */
+            while (nn_queue_pop (tasks) != NULL) {
+                continue;
+            }
+            nn_queue_term (tasks);
+            status = NN_STATUS_STOP;
+            break;
+        }
+
+        /*  It's a user-defined task. Notify the user that it has
+        arrived in the worker thread. */
+        task = nn_cont (item, struct nn_worker_task, item);
+        nn_ctx_enter (task->owner->ctx);
+        nn_fsm_feed (task->owner, task->src, NN_WORKER_TASK_EXECUTE, task);
+        nn_ctx_leave (task->owner->ctx);
+    }
+    nn_queue_term (tasks);
+    return status;
+}
+
 static void nn_worker_routine (void *arg)
 {
     int rc;
@@ -258,14 +308,13 @@ static void nn_worker_routine (void *arg)
     struct nn_poller_hndl *phndl;
     struct nn_timerset_hndl *thndl;
     struct nn_queue tasks;
-    struct nn_queue_item *item;
-    struct nn_worker_task *task;
     struct nn_worker_fd *fd;
     struct nn_worker_timer *timer;
-    int paused;
+    int paused = 0;
+    int stop = 0;
+    int status = NN_STATUS_IDLE;
 
     self = (struct nn_worker*) arg;
-    paused = 0;
 
     /*  Infinite loop. It will be interrupted only when the object is
         shut down. */
@@ -273,6 +322,19 @@ static void nn_worker_routine (void *arg)
 
         /*  If the worker thread is marked as paused, do so. */
         if (nn_slow (paused)) {
+
+            /*  Process all non-io worker tasks until none are left */
+            while (!nn_queue_empty(&self->tasks))
+            {
+                nn_mutex_lock (&self->sync);
+                nn_efd_unsignal (&self->efd);
+                memcpy (&tasks, &self->tasks, sizeof (tasks));
+                nn_queue_init (&self->tasks);
+                nn_mutex_unlock (&self->sync);
+
+                status = nn_worker_process_tasks (self, &tasks);
+                stop = stop || status == NN_STATUS_STOP;
+            }
 
             nn_mutex_lock (&self->resume_mutex);
 
@@ -297,6 +359,9 @@ static void nn_worker_routine (void *arg)
             nn_mutex_unlock (&self->resume_mutex);
 
             paused = 0;
+
+            if (nn_slow (stop))
+                return;
         }
 
         /*  Wait for new events and/or timeouts. */
@@ -338,42 +403,16 @@ static void nn_worker_routine (void *arg)
                 nn_queue_init (&self->tasks);
                 nn_mutex_unlock (&self->sync);
 
-                while (1) {
-
-                    /*  Next worker task. */
-                    item = nn_queue_pop (&tasks);
-                    if (nn_slow (!item))
-                        break;
-
-                    /*  If the worker thread is asked to pause, schedule a
-                        pause after everything else is processed. */
-                    if (nn_slow (item == &self->pause)) {
-                        paused = 1;
-                        continue;
-                    }
-
-                    /*  If the worker thread is asked to stop, do so. */
-                    if (nn_slow (item == &self->stop)) {
-			/*  Make sure we remove all the other workers from
-			    the queue, because we're not doing anything with
-			    them. */
-			while (nn_queue_pop (&tasks) != NULL) {
-				continue;
-			}
-                        nn_queue_term (&tasks);
-                        return;
-                    }
-
-                    /*  It's a user-defined task. Notify the user that it has
-                        arrived in the worker thread. */
-                    task = nn_cont (item, struct nn_worker_task, item);
-                    nn_ctx_enter (task->owner->ctx);
-                    nn_fsm_feed (task->owner, task->src,
-                        NN_WORKER_TASK_EXECUTE, task);
-                    nn_ctx_leave (task->owner->ctx);
+                status = nn_worker_process_tasks (self, &tasks);
+                switch (status) {
+                case NN_STATUS_STOP:
+                    return;
+                case NN_STATUS_PAUSE:
+                    paused = 1;
+                case NN_STATUS_IDLE:
+                default:
+                    continue;
                 }
-                nn_queue_term (&tasks);
-                continue;
             }
 
             /*  It's a true I/O event. Invoke the handler. */

--- a/src/aio/worker_posix.inc
+++ b/src/aio/worker_posix.inc
@@ -2,6 +2,7 @@
     Copyright (c) 2013-2014 Martin Sustrik  All rights reserved.
     Copyright (c) 2013 GoPivotal, Inc.  All rights reserved.
     Copyright 2016 Garrett D'Amore <garrett@damore.org>
+    Copyright 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -118,6 +119,15 @@ int nn_worker_init (struct nn_worker *self)
     return 0;
 }
 
+void nn_worker_force_cleanup (struct nn_worker *self) {
+    nn_timerset_term (&self->timerset);
+    nn_poller_term (&self->poller);
+    nn_efd_term (&self->efd);
+    nn_queue_item_term (&self->stop);
+    nn_queue_term (&self->tasks);
+    nn_mutex_term (&self->sync);
+}
+
 void nn_worker_term (struct nn_worker *self)
 {
     /*  Ask worker thread to terminate. */
@@ -130,12 +140,7 @@ void nn_worker_term (struct nn_worker *self)
     nn_thread_term (&self->thread);
 
     /*  Clean up. */
-    nn_timerset_term (&self->timerset);
-    nn_poller_term (&self->poller);
-    nn_efd_term (&self->efd);
-    nn_queue_item_term (&self->stop);
-    nn_queue_term (&self->tasks);
-    nn_mutex_term (&self->sync);
+    nn_worker_force_cleanup (self);
 }
 
 void nn_worker_execute (struct nn_worker *self, struct nn_worker_task *task)

--- a/src/aio/worker_posix.inc
+++ b/src/aio/worker_posix.inc
@@ -37,6 +37,7 @@
 
 /*  Private functions. */
 static void nn_worker_routine (void *arg);
+static void nn_worker_postfork_routine (void *arg);
 
 void nn_worker_fd_init (struct nn_worker_fd *self, int src,
     struct nn_fsm *owner)
@@ -163,7 +164,7 @@ void nn_worker_revive (struct nn_worker *self)
     nn_mutex_init (&self->pause_mutex);
 
     /*  Revive the worker thread */
-    nn_thread_init (&self->thread, nn_worker_routine, self);
+    nn_thread_init (&self->thread, nn_worker_postfork_routine, self);
 }
 
 void nn_worker_force_cleanup (struct nn_worker *self) {
@@ -254,6 +255,20 @@ void nn_worker_cancel (struct nn_worker *self, struct nn_worker_task *task)
     nn_mutex_unlock (&self->sync);
 }
 
+static inline void nn_worker_copy_task_queue (struct nn_worker *self, 
+    struct nn_queue *dst)
+{
+    /*  Make a local copy of the task queue. This way
+        the application threads are not blocked and can post new
+        tasks while the existing tasks are being processed. Also,
+        new tasks can be posted from within task handlers. */
+    nn_mutex_lock (&self->sync);
+    nn_efd_unsignal (&self->efd);
+    memcpy (dst, &self->tasks, sizeof (*dst));
+    nn_queue_init (&self->tasks);
+    nn_mutex_unlock (&self->sync);
+}
+
 static int nn_worker_process_tasks (struct nn_worker *self, struct nn_queue *tasks)
 {
     struct nn_queue_item *item;
@@ -300,6 +315,54 @@ static int nn_worker_process_tasks (struct nn_worker *self, struct nn_queue *tas
     return status;
 }
 
+static void nn_worker_postfork_routine (void *arg)
+{
+    int rc;
+    struct nn_worker *self;
+    int pevent;
+    struct nn_poller_hndl *phndl;
+    struct nn_queue tasks;
+    int status = NN_STATUS_IDLE;
+
+    self = (struct nn_worker*) arg;
+
+    /*  Infinite loop. It will be interrupted only when the object is
+        shut down. */
+    while (1) {
+
+        /*  Wait for new events and/or timeouts. */
+        rc = nn_poller_wait (&self->poller,
+            nn_timerset_timeout (&self->timerset));
+        errnum_assert (rc == 0, -rc);
+
+        /*  Process all events from the poller. */
+        while (1) {
+
+            /*  Get next poller event, such as IN or OUT. */
+            rc = nn_poller_event (&self->poller, &pevent, &phndl);
+            if (nn_slow (rc == -EAGAIN))
+                break;
+
+            /*  Only process worker tasks. */
+            if (phndl != &self->efd_hndl)
+                continue;
+
+            nn_assert (pevent == NN_POLLER_IN);
+
+            nn_worker_copy_task_queue (self, &tasks);
+            status = nn_worker_process_tasks (self, &tasks);
+            switch (status) {
+            case NN_STATUS_STOP:
+                return;
+            case NN_STATUS_IDLE:
+            default:
+                continue;
+            }
+        }
+    }
+
+}
+
 static void nn_worker_routine (void *arg)
 {
     int rc;
@@ -326,12 +389,7 @@ static void nn_worker_routine (void *arg)
             /*  Process all non-io worker tasks until none are left */
             while (!nn_queue_empty(&self->tasks))
             {
-                nn_mutex_lock (&self->sync);
-                nn_efd_unsignal (&self->efd);
-                memcpy (&tasks, &self->tasks, sizeof (tasks));
-                nn_queue_init (&self->tasks);
-                nn_mutex_unlock (&self->sync);
-
+                nn_worker_copy_task_queue (self, &tasks);
                 status = nn_worker_process_tasks (self, &tasks);
                 stop = stop || status == NN_STATUS_STOP;
             }
@@ -393,16 +451,7 @@ static void nn_worker_routine (void *arg)
             if (phndl == &self->efd_hndl) {
                 nn_assert (pevent == NN_POLLER_IN);
 
-                /*  Make a local copy of the task queue. This way
-                    the application threads are not blocked and can post new
-                    tasks while the existing tasks are being processed. Also,
-                    new tasks can be posted from within task handlers. */
-                nn_mutex_lock (&self->sync);
-                nn_efd_unsignal (&self->efd);
-                memcpy (&tasks, &self->tasks, sizeof (tasks));
-                nn_queue_init (&self->tasks);
-                nn_mutex_unlock (&self->sync);
-
+                nn_worker_copy_task_queue (self, &tasks);
                 status = nn_worker_process_tasks (self, &tasks);
                 switch (status) {
                 case NN_STATUS_STOP:

--- a/src/aio/worker_posix.inc
+++ b/src/aio/worker_posix.inc
@@ -127,6 +127,41 @@ int nn_worker_init (struct nn_worker *self)
     return 0;
 }
 
+void nn_worker_revive (struct nn_worker *self)
+{
+    /*  Collect resources allocated by the dead thread.
+        This is only relevant when the pthread no longer exists, and
+        we do not check this function call for failures. */
+    pthread_join (self->thread.handle, NULL);
+
+    /*  Revive poller  */
+    nn_poller_revive (&self->poller);
+
+    /*  Reset event file descriptor  */
+    nn_poller_rm (&self->poller, &self->efd_hndl);
+    nn_efd_term (&self->efd);
+    nn_efd_init (&self->efd);
+    nn_poller_add (&self->poller, nn_efd_getfd (&self->efd), &self->efd_hndl);
+    nn_poller_set_in (&self->poller, &self->efd_hndl);
+
+    /*  Empty the current worker queue */
+    while (nn_queue_pop (&self->tasks) != NULL) {
+        continue;
+    }
+
+    /*  Reinitialize the pause mutexes and condition variables since they
+        are in an invalid state after a fork(2). */
+    self->paused = 0;
+    self->resumed = 0;
+    nn_cond_init (&self->resume_cond);
+    nn_mutex_init (&self->resume_mutex);
+    nn_cond_init (&self->pause_cond);
+    nn_mutex_init (&self->pause_mutex);
+
+    /*  Revive the worker thread */
+    nn_thread_init (&self->thread, nn_worker_routine, self);
+}
+
 void nn_worker_force_cleanup (struct nn_worker *self) {
     /*  Wait till worker thread terminates. */
     nn_thread_term (&self->thread);
@@ -227,12 +262,42 @@ static void nn_worker_routine (void *arg)
     struct nn_worker_task *task;
     struct nn_worker_fd *fd;
     struct nn_worker_timer *timer;
+    int paused;
 
     self = (struct nn_worker*) arg;
+    paused = 0;
 
     /*  Infinite loop. It will be interrupted only when the object is
         shut down. */
     while (1) {
+
+        /*  If the worker thread is marked as paused, do so. */
+        if (nn_slow (paused)) {
+
+            nn_mutex_lock (&self->resume_mutex);
+
+            /*  Notify the calling thread that the worker paused  */
+            nn_mutex_lock (&self->pause_mutex);
+            self->paused = 1;
+            nn_cond_signal (&self->pause_cond);
+            nn_mutex_unlock (&self->pause_mutex);
+
+            /*  Pause until the thread is resumed  */
+            while (self->paused) {
+                nn_cond_wait (&self->resume_cond,
+                    &self->resume_mutex);
+            }
+
+            /*  Notify the calling thread that the worker resumed */
+            nn_mutex_lock (&self->pause_mutex);
+            self->resumed = 1;
+            nn_cond_signal (&self->pause_cond);
+            nn_mutex_unlock (&self->pause_mutex);
+
+            nn_mutex_unlock (&self->resume_mutex);
+
+            paused = 0;
+        }
 
         /*  Wait for new events and/or timeouts. */
         rc = nn_poller_wait (&self->poller,
@@ -280,30 +345,10 @@ static void nn_worker_routine (void *arg)
                     if (nn_slow (!item))
                         break;
 
-                    /*  If the worker thread is asked to pause, do so. */
+                    /*  If the worker thread is asked to pause, schedule a
+                        pause after everything else is processed. */
                     if (nn_slow (item == &self->pause)) {
-
-                        nn_mutex_lock (&self->resume_mutex);
-
-                        /*  Notify the calling thread that the worker paused  */
-                        nn_mutex_lock (&self->pause_mutex);
-                        self->paused = 1;
-                        nn_cond_signal (&self->pause_cond);
-                        nn_mutex_unlock (&self->pause_mutex);
-
-                        /*  Pause until the thread is resumed  */
-                        while (self->paused) {
-                            nn_cond_wait (&self->resume_cond,
-                                          &self->resume_mutex);
-                        }
-
-                        /*  Notify the calling thread that the worker resumed */
-                        nn_mutex_lock (&self->pause_mutex);
-                        self->resumed = 1;
-                        nn_cond_signal (&self->pause_cond);
-                        nn_mutex_unlock (&self->pause_mutex);
-
-                        nn_mutex_unlock (&self->resume_mutex);
+                        paused = 1;
                         continue;
                     }
 

--- a/src/core/global.c
+++ b/src/core/global.c
@@ -1258,7 +1258,8 @@ int nn_global_postfork_cleanup ()
         for (i = 0; i != NN_MAX_SOCKETS; ++i)
             if (self.socks [i]) {
                 nn_sock_stop (self.socks [i]);
-                nn_sock_rele (self.socks [i]);
+                while (self.socks [i]->holds > 0)
+                    nn_sock_rele (self.socks [i]);
                 nn_sock_term (self.socks [i]);
                 nn_free (self.socks [i]);
                 self.socks [i] = NULL;

--- a/src/core/global.c
+++ b/src/core/global.c
@@ -1186,25 +1186,6 @@ void nn_global_rele_socket(struct nn_sock *sock)
     nn_glock_unlock();
 }
 
-int nn_setopt (int option, const void *optval, size_t optvallen)
-{
-    switch (option) {
-    case NN_FORK_STRATEGY:
-        nn_assert(optvallen == sizeof (int));
-        int idx = *(const int *) optval;
-        if (idx < 0 || idx >= NN_FORK_MAX_) {
-            errno = EINVAL;
-            break;
-        }
-        nn_fork_strategy = &nn_fork_strategies[idx];
-        return 0;
-    default:
-        errno = ENOPROTOOPT;
-        break;
-    }
-    return -1;
-}
-
 void nn_global_lock_all_sockets (void)
 {
     int i;

--- a/src/core/global.c
+++ b/src/core/global.c
@@ -1198,6 +1198,22 @@ void nn_global_lock_all_sockets (void)
     }
 }
 
+void nn_global_reset_all_socket_locks (void)
+{
+    int i;
+    struct nn_ctx *ctx;
+    nn_assert(nn_is_glock_held());
+
+    nn_mutex_reset (&self.ctx.sync);
+    if (self.socks && self.nsocks) {
+        for (i = 0; i != NN_MAX_SOCKETS; ++i)
+            if (self.socks [i]) {
+                ctx = nn_sock_getctx (self.socks [i]);
+                nn_mutex_reset (&ctx->sync);
+            }
+    }
+}
+
 void nn_global_unlock_all_sockets (void)
 {
     int i;

--- a/src/core/global.c
+++ b/src/core/global.c
@@ -1156,3 +1156,13 @@ void nn_global_rele_socket(struct nn_sock *sock)
     nn_sock_rele(sock);
     nn_glock_unlock();
 }
+
+int nn_setopt (int option, const void *optval, size_t optvallen)
+{
+    switch (option) {
+    default:
+        errno = ENOPROTOOPT;
+        break;
+    }
+    return -1;
+}

--- a/src/core/global.c
+++ b/src/core/global.c
@@ -135,15 +135,6 @@ struct nn_global {
     int state;
 
     int print_errors;
-
-#ifndef NN_HAVE_WINDOWS
-    volatile int fork_lock;
-    struct nn_mutex fork_sync;
-    struct nn_cond fork_cond;
-    volatile uint32_t io_operations;
-    struct nn_mutex ioop_sync;
-    struct nn_cond ioop_cond;
-#endif
 };
 
 /*  Singleton object containing the global state of the library. */
@@ -263,12 +254,6 @@ static void nn_global_init (void)
 #ifndef NN_HAVE_WINDOWS
     /* Register atfork handlers */
     errno_assert(nn_setup_atfork_handlers () == 0);
-    nn_mutex_init (&self.fork_sync);
-    nn_mutex_init (&self.ioop_sync);
-    nn_cond_init (&self.fork_cond);
-    nn_cond_init (&self.ioop_cond);
-    self.io_operations = 0;
-    self.fork_lock = 0;
 #endif
 
     /*  Start the worker threads. */
@@ -1204,7 +1189,6 @@ void nn_global_reset_all_socket_locks (void)
     struct nn_ctx *ctx;
     nn_assert(nn_is_glock_held());
 
-    nn_mutex_reset (&self.ctx.sync);
     if (self.socks && self.nsocks) {
         for (i = 0; i != NN_MAX_SOCKETS; ++i)
             if (self.socks [i]) {

--- a/src/core/global.h
+++ b/src/core/global.h
@@ -38,4 +38,7 @@ int nn_global_postfork_cleanup ();
 void nn_global_lock_all_sockets (void);
 void nn_global_unlock_all_sockets (void);
 
+void nn_global_fork_lock (void);
+void nn_global_fork_unlock (void);
+
 #endif

--- a/src/core/global.h
+++ b/src/core/global.h
@@ -41,4 +41,6 @@ void nn_global_unlock_all_sockets (void);
 void nn_global_fork_lock (void);
 void nn_global_fork_unlock (void);
 
+void nn_global_reset_all_socket_locks (void);
+
 #endif

--- a/src/core/global.h
+++ b/src/core/global.h
@@ -34,4 +34,8 @@ int nn_global_print_errors();
 /* Force clean up nanomsg after a fork, when everything is broken. */
 int nn_global_postfork_cleanup ();
 
+/* Enter & leave the context of each socket. */
+void nn_global_lock_all_sockets (void);
+void nn_global_unlock_all_sockets (void);
+
 #endif

--- a/src/nn.h
+++ b/src/nn.h
@@ -349,18 +349,6 @@ NN_EXPORT  struct nn_cmsghdr *nn_cmsg_nxthdr_ (
 /*  Send/recv options.                                                        */
 #define NN_DONTWAIT 1
 
-/*  Global options.                                                           */
-#define NN_FORK_STRATEGY 1
-
-/*  Fork strategies.                                                          */
-/*  ABI warning: do not reorder, add new entries before NN_FORK_MAX_.         */
-enum nn_fork_strategy_kind {
-    NN_FORK_NONE = 1,
-    NN_FORK_RESET,
-
-    NN_FORK_MAX_
-};
-
 /*  Ancillary data.                                                           */
 #define PROTO_SP 1
 #define SP_HDR 1
@@ -371,7 +359,6 @@ NN_EXPORT int nn_setsockopt (int s, int level, int option, const void *optval,
     size_t optvallen);
 NN_EXPORT int nn_getsockopt (int s, int level, int option, void *optval,
     size_t *optvallen);
-NN_EXPORT int nn_setopt (int option, const void *optval, size_t optvallen);
 NN_EXPORT int nn_bind (int s, const char *addr);
 NN_EXPORT int nn_connect (int s, const char *addr);
 NN_EXPORT int nn_shutdown (int s, int how);

--- a/src/nn.h
+++ b/src/nn.h
@@ -349,6 +349,18 @@ NN_EXPORT  struct nn_cmsghdr *nn_cmsg_nxthdr_ (
 /*  Send/recv options.                                                        */
 #define NN_DONTWAIT 1
 
+/*  Global options.                                                           */
+#define NN_FORK_STRATEGY 1
+
+/*  Fork strategies.                                                          */
+/*  ABI warning: do not reorder, add new entries before NN_FORK_MAX_.         */
+enum nn_fork_strategy_kind {
+    NN_FORK_NONE = 1,
+    NN_FORK_RESET,
+
+    NN_FORK_MAX_
+};
+
 /*  Ancillary data.                                                           */
 #define PROTO_SP 1
 #define SP_HDR 1

--- a/src/nn.h
+++ b/src/nn.h
@@ -359,6 +359,7 @@ NN_EXPORT int nn_setsockopt (int s, int level, int option, const void *optval,
     size_t optvallen);
 NN_EXPORT int nn_getsockopt (int s, int level, int option, void *optval,
     size_t *optvallen);
+NN_EXPORT int nn_setopt (int option, const void *optval, size_t optvallen);
 NN_EXPORT int nn_bind (int s, const char *addr);
 NN_EXPORT int nn_connect (int s, const char *addr);
 NN_EXPORT int nn_shutdown (int s, int how);

--- a/src/utils/cond.c
+++ b/src/utils/cond.c
@@ -1,0 +1,82 @@
+/*
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom
+    the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#include "cond.h"
+#include "err.h"
+
+#ifdef NN_HAVE_WINDOWS
+/*  Not implemented (no current usage in the library on windows)  */
+
+void nn_cond_init (struct nn_cond *self)
+{
+    nn_assert (0);
+}
+
+void nn_cond_term (struct nn_cond *self)
+{
+    nn_assert (0);
+}
+
+void nn_cond_wait (struct nn_cond *self, struct nn_mutex *mut)
+{
+    nn_assert (0);
+}
+
+void nn_cond_signal (struct nn_cond *self)
+{
+    nn_assert (0);
+}
+#else
+
+void nn_cond_init (struct nn_cond *self)
+{
+    int rc;
+
+    rc = pthread_cond_init (&self->cond, NULL);
+    errnum_assert (rc == 0, rc);
+}
+
+void nn_cond_term (struct nn_cond *self)
+{
+    int rc;
+
+    rc = pthread_cond_destroy (&self->cond);
+    errnum_assert (rc == 0, rc);
+}
+
+void nn_cond_wait (struct nn_cond *self, struct nn_mutex *mut)
+{
+    int rc;
+
+    rc = pthread_cond_wait (&self->cond, &mut->mutex);
+    errnum_assert (rc == 0, rc);
+}
+
+void nn_cond_signal (struct nn_cond *self)
+{
+    int rc;
+
+    rc = pthread_cond_broadcast (&self->cond);
+    errnum_assert (rc == 0, rc);
+}
+
+#endif

--- a/src/utils/cond.h
+++ b/src/utils/cond.h
@@ -1,0 +1,45 @@
+/*
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom
+    the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#ifndef NN_COND_INCLUDED
+#define NN_COND_INCLUDED
+
+#include "mutex.h"
+
+#ifndef NN_HAVE_WINDOWS
+#include <pthread.h>
+#endif
+
+#ifdef NN_HAVE_WINDOWS
+struct nn_cond;
+#else
+struct nn_cond {
+    pthread_cond_t cond;
+};
+#endif
+
+void nn_cond_init (struct nn_cond *self);
+void nn_cond_term (struct nn_cond *self);
+void nn_cond_wait (struct nn_cond *self, struct nn_mutex *mut);
+void nn_cond_signal (struct nn_cond *self);
+
+#endif

--- a/src/utils/fork.c
+++ b/src/utils/fork.c
@@ -37,31 +37,35 @@ static void nn_prefork_reset (void)
     nn_mutex_lock (&w->sync);
 
     nn_glock_lock ();
+    nn_global_lock_all_sockets ();
 }
 
 static void nn_postfork_parent_reset (void)
 {
-    nn_glock_unlock ();
-
     /* Unlock the worker */
     struct nn_pool *pool = nn_global_getpool();
     struct nn_worker *w = &pool->worker;
 
+    nn_global_unlock_all_sockets ();
+
     nn_mutex_unlock (&w->sync);
+
+    nn_glock_unlock ();
 }
 
 static void nn_postfork_child_reset (void)
 {
-    nn_glock_unlock ();
-
     /* Unlock the worker and reset */
     struct nn_pool *pool = nn_global_getpool();
     struct nn_worker *w = &pool->worker;
+
+    nn_global_unlock_all_sockets ();
 
     nn_mutex_unlock (&w->sync);
     nn_worker_force_cleanup (w);
 
     nn_global_postfork_cleanup ();
+    nn_glock_unlock ();
 }
 
 /* Set up all strategies */

--- a/src/utils/fork.c
+++ b/src/utils/fork.c
@@ -28,21 +28,17 @@
 
 /* Reset strategy: We close all sockets in the child on fork */
 
-#include <stdio.h>
-
 static void nn_prefork_reset (void)
 {
     /* Retrieve the worker and lock it */
     struct nn_pool *pool = nn_global_getpool();
     struct nn_worker *w = &pool->worker;
 
-    nn_global_fork_lock ();
-
     nn_worker_pause (w);
-    nn_mutex_lock (&w->sync);
 
     nn_glock_lock ();
     nn_global_lock_all_sockets ();
+    nn_mutex_lock (&w->sync);
 }
 
 static void nn_postfork_parent_reset (void)
@@ -51,14 +47,11 @@ static void nn_postfork_parent_reset (void)
     struct nn_pool *pool = nn_global_getpool();
     struct nn_worker *w = &pool->worker;
 
-    nn_global_unlock_all_sockets ();
-
-    nn_global_fork_unlock ();
-
     nn_mutex_unlock (&w->sync);
-    nn_worker_resume (w);
-
+    nn_global_unlock_all_sockets ();
     nn_glock_unlock ();
+
+    nn_worker_resume (w);
 }
 
 static void nn_postfork_child_reset (void)
@@ -67,15 +60,14 @@ static void nn_postfork_child_reset (void)
     struct nn_pool *pool = nn_global_getpool();
     struct nn_worker *w = &pool->worker;
 
-    nn_global_unlock_all_sockets ();
-    nn_global_fork_unlock ();
-
     /* Don't try to resume the dead thread, but simply release the lock */
     nn_mutex_unlock (&w->resume_mutex);
-    nn_mutex_unlock (&w->sync);
 
     /* Revive the dead worker */
     nn_worker_revive (w);
+
+    nn_mutex_unlock (&w->sync);
+    nn_global_unlock_all_sockets ();
 
     nn_global_postfork_cleanup ();
     nn_glock_unlock ();

--- a/src/utils/fork.c
+++ b/src/utils/fork.c
@@ -1,0 +1,107 @@
+/*
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom
+    the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#include <pthread.h>
+#include "fork.h"
+#include "glock.h"
+#include "../core/global.h"
+#include "../aio/pool.h"
+
+/* Reset strategy: We close all sockets in the child on fork */
+
+static void nn_prefork_reset (void)
+{
+    /* Retrieve the worker and lock it */
+    struct nn_pool *pool = nn_global_getpool();
+    struct nn_worker *w = &pool->worker;
+
+    nn_mutex_lock (&w->sync);
+
+    nn_glock_lock ();
+}
+
+static void nn_postfork_parent_reset (void)
+{
+    nn_glock_unlock ();
+
+    /* Unlock the worker */
+    struct nn_pool *pool = nn_global_getpool();
+    struct nn_worker *w = &pool->worker;
+
+    nn_mutex_unlock (&w->sync);
+}
+
+static void nn_postfork_child_reset (void)
+{
+    nn_glock_unlock ();
+
+    /* Unlock the worker and reset */
+    struct nn_pool *pool = nn_global_getpool();
+    struct nn_worker *w = &pool->worker;
+
+    nn_mutex_unlock (&w->sync);
+    nn_worker_force_cleanup (w);
+
+    nn_global_postfork_cleanup ();
+}
+
+/* Set up all strategies */
+
+struct nn_fork_strategy *nn_fork_strategy = &nn_fork_strategies[NN_FORK_NONE];
+
+static void nn_prefork (void)
+{
+    nn_fork_strategy->prefork_fn ();
+}
+
+static void nn_postfork_parent (void)
+{
+    nn_fork_strategy->postfork_parent_fn ();
+}
+
+static void nn_postfork_child (void)
+{
+    nn_fork_strategy->postfork_child_fn ();
+}
+
+int nn_setup_atfork_handlers (void)
+{
+    int res = pthread_atfork (nn_prefork, nn_postfork_parent, nn_postfork_child);
+    if (res != 0) {
+        errno = res;
+        return -1;
+    }
+    return 0;
+}
+
+static void nothing (void) {}
+
+struct nn_fork_strategy nn_fork_strategies[] =
+{
+    [NN_FORK_NONE]  = {nothing, nothing, nothing},
+    [NN_FORK_RESET] = {
+        nn_prefork_reset,
+        nn_postfork_parent_reset,
+        nn_postfork_child_reset
+    },
+};
+

--- a/src/utils/fork.h
+++ b/src/utils/fork.h
@@ -23,17 +23,6 @@
 #ifndef NN_FORK_INCLUDED
 #define NN_FORK_INCLUDED
 
-#include "../nn.h"
-
-struct nn_fork_strategy {
-    void (*prefork_fn)(void);
-    void (*postfork_parent_fn)(void);
-    void (*postfork_child_fn)(void);
-};
-
-extern struct nn_fork_strategy nn_fork_strategies[NN_FORK_MAX_];
-extern struct nn_fork_strategy *nn_fork_strategy;
-
 int nn_setup_atfork_handlers(void);
 
 #endif /* !NN_FORK_INCLUDED */

--- a/src/utils/fork.h
+++ b/src/utils/fork.h
@@ -1,5 +1,4 @@
 /*
-    Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
     Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,17 +20,20 @@
     IN THE SOFTWARE.
 */
 
-#ifndef NN_GLOBAL_INCLUDED
-#define NN_GLOBAL_INCLUDED
+#ifndef NN_FORK_INCLUDED
+#define NN_FORK_INCLUDED
 
-/*  Provides access to the list of available transports. */
-struct nn_transport *nn_global_transport (int id);
+#include "../nn.h"
 
-/*  Returns the global worker thread pool. */
-struct nn_pool *nn_global_getpool ();
-int nn_global_print_errors();
+struct nn_fork_strategy {
+    void (*prefork_fn)(void);
+    void (*postfork_parent_fn)(void);
+    void (*postfork_child_fn)(void);
+};
 
-/* Force clean up nanomsg after a fork, when everything is broken. */
-int nn_global_postfork_cleanup ();
+extern struct nn_fork_strategy nn_fork_strategies[NN_FORK_MAX_];
+extern struct nn_fork_strategy *nn_fork_strategy;
 
-#endif
+int nn_setup_atfork_handlers(void);
+
+#endif /* !NN_FORK_INCLUDED */

--- a/src/utils/glock.c
+++ b/src/utils/glock.c
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012 Martin Sustrik  All rights reserved.
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -22,6 +23,8 @@
 
 #include "glock.h"
 
+static int nn_glock_held = 0;
+
 #if defined NN_HAVE_WINDOWS
 
 #include "win.h"
@@ -40,11 +43,13 @@ void nn_glock_lock (void)
 {
     nn_glock_init ();
     EnterCriticalSection (&nn_glock_cs);
+    nn_glock_held = 1;
 }
 
 void nn_glock_unlock (void)
 {
     nn_glock_init ();
+    nn_glock_held = 0;
     LeaveCriticalSection (&nn_glock_cs);
 }
 
@@ -62,15 +67,21 @@ void nn_glock_lock (void)
 
     rc = pthread_mutex_lock (&nn_glock_mutex);
     errnum_assert (rc == 0, rc);
+    nn_glock_held = 1;
 }
 
 void nn_glock_unlock (void)
 {
     int rc;
 
+    nn_glock_held = 0;
     rc = pthread_mutex_unlock (&nn_glock_mutex);
     errnum_assert (rc == 0, rc);
 }
 
 #endif
 
+int nn_is_glock_held (void)
+{
+    return nn_glock_held;
+}

--- a/src/utils/glock.c
+++ b/src/utils/glock.c
@@ -53,6 +53,10 @@ void nn_glock_unlock (void)
     LeaveCriticalSection (&nn_glock_cs);
 }
 
+void nn_glock_reset (void)
+{
+}
+
 #else
 
 #include "err.h"
@@ -76,6 +80,20 @@ void nn_glock_unlock (void)
 
     nn_glock_held = 0;
     rc = pthread_mutex_unlock (&nn_glock_mutex);
+    errnum_assert (rc == 0, rc);
+}
+
+void nn_glock_reset (void)
+{
+    int rc;
+
+    rc = pthread_mutex_unlock (&nn_glock_mutex);
+    errnum_assert (rc == 0, rc);
+    pthread_mutex_destroy (&nn_glock_mutex);
+
+    rc = pthread_mutex_init (&nn_glock_mutex, NULL);
+    errnum_assert (rc == 0, rc);
+    rc = pthread_mutex_lock (&nn_glock_mutex);
     errnum_assert (rc == 0, rc);
 }
 

--- a/src/utils/glock.h
+++ b/src/utils/glock.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012 Martin Sustrik  All rights reserved.
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -28,6 +29,7 @@
 
 void nn_glock_lock (void);
 void nn_glock_unlock (void);
+int nn_is_glock_held (void);
 
 #endif
 

--- a/src/utils/glock.h
+++ b/src/utils/glock.h
@@ -30,6 +30,7 @@
 void nn_glock_lock (void);
 void nn_glock_unlock (void);
 int nn_is_glock_held (void);
+void nn_glock_reset (void);
 
 #endif
 

--- a/src/utils/mutex.c
+++ b/src/utils/mutex.c
@@ -45,6 +45,10 @@ void nn_mutex_unlock (struct nn_mutex *self)
     LeaveCriticalSection (&self->mutex);
 }
 
+void nn_mutex_reset (struct nn_mutex *self)
+{
+}
+
 #else
 
 void nn_mutex_init (struct nn_mutex *self)
@@ -76,6 +80,20 @@ void nn_mutex_unlock (struct nn_mutex *self)
     int rc;
 
     rc = pthread_mutex_unlock (&self->mutex);
+    errnum_assert (rc == 0, rc);
+}
+
+void nn_mutex_reset (struct nn_mutex *self)
+{
+    int rc;
+
+    rc = pthread_mutex_unlock (&self->mutex);
+    errnum_assert (rc == 0, rc);
+    pthread_mutex_destroy (&self->mutex);
+
+    rc = pthread_mutex_init (&self->mutex, NULL);
+    errnum_assert (rc == 0, rc);
+    rc = pthread_mutex_lock (&self->mutex);
     errnum_assert (rc == 0, rc);
 }
 

--- a/src/utils/mutex.h
+++ b/src/utils/mutex.h
@@ -50,5 +50,7 @@ void nn_mutex_lock (struct nn_mutex *self);
 /*  Unlock the mutex. Behaviour of unlocking an unlocked mutex is undefined */
 void nn_mutex_unlock (struct nn_mutex *self);
 
+void nn_mutex_reset (struct nn_mutex *self);
+
 #endif
 

--- a/tests/fork.c
+++ b/tests/fork.c
@@ -38,9 +38,6 @@ int main ()
 {
     int sb, sc, sb_alt, sc_alt;
 
-    int fstrat = NN_FORK_RESET;
-    nn_setopt(NN_FORK_STRATEGY, &fstrat, sizeof (fstrat));
-
     /* Do some background work */
 
     sb_alt = test_socket (AF_SP, NN_PAIR);

--- a/tests/fork.c
+++ b/tests/fork.c
@@ -1,0 +1,92 @@
+/*
+    Copyright (c) 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom
+    the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#include "../src/nn.h"
+#include "../src/pair.h"
+#include "../src/ipc.h"
+#include "../src/reqrep.h"
+
+#include "testutil.h"
+
+#include <unistd.h>
+
+/*  Test behaviour on fork. */
+
+#define SOCKET_ADDRESS "ipc://test.ipc"
+#define ALT_SOCKET_ADDRESS "ipc://test2.ipc"
+
+int main ()
+{
+    int sb, sc, sb_alt, sc_alt;
+
+    int fstrat = NN_FORK_RESET;
+    nn_setopt(NN_FORK_STRATEGY, &fstrat, sizeof (fstrat));
+
+    /* Do some background work */
+
+    sb_alt = test_socket (AF_SP, NN_PAIR);
+    test_bind (sb_alt, ALT_SOCKET_ADDRESS);
+
+    sc_alt = test_socket (AF_SP, NN_PAIR);
+    test_connect (sc_alt, ALT_SOCKET_ADDRESS);
+
+    test_send (sc_alt, "0123456789012345678901234567890123456789");
+    test_recv (sb_alt, "0123456789012345678901234567890123456789");
+    test_send (sb_alt, "0123456789012345678901234567890123456789");
+
+    /* Fork with a pair on each end */
+
+    sb = test_socket (AF_SP, NN_REQ);
+    test_bind (sb, SOCKET_ADDRESS);
+
+    pid_t pid = fork();
+    nn_assert(pid != -1);
+
+    if (pid == 0) {
+        nn_assert(nn_close(sb) == -1);
+        nn_assert(errno == ETERM);
+
+        /* Try to connect on the child's end */
+        sc = test_socket (AF_SP, NN_REP);
+        test_connect (sc, SOCKET_ADDRESS);
+
+        /* Consume the sent data and reply */
+        test_recv (sc, "0123456789012345678901234567890123456789");
+        test_send (sc, "0123456789012345678901234567890123456789");
+
+        nn_close (sc);
+    } else {
+        /* Send data to the child and expect a response */
+        test_send (sb, "0123456789012345678901234567890123456789");
+        test_recv (sb, "0123456789012345678901234567890123456789");
+
+        nn_close (sb);
+
+        /* Recieve late background work */
+        test_recv (sc_alt, "0123456789012345678901234567890123456789");
+
+        nn_close(sc_alt);
+        nn_close(sb_alt);
+    }
+    return 0;
+}
+


### PR DESCRIPTION
This addresses issue #582.

This PR is twofold:
1. It first adds the `nn_setopt(3)` function in the API, to set global nanomsg options that are not bound to a specific socket.
2. It adds at-fork handling to the library, as well as two strategies: `NN_FORK_NONE` (do nothing, current behaviour) and `NN_FORK_RESET` (terminate and cleanup completely nanomsg in the child process).

This is still a work in progress -- I am opening this for reviews, and most notably: 
- I want to know if adding `nn_setopt` is a good idea. I added it because I felt like adding a singular function like `nn_set_atfork_strategy` wouldn't follow the current design of the library, and there might be other "global" options in the future, but not everyone might agree with me.
- I provided the `NN_FORK_RESET` strategy as an option, rather than the default. It might have been more sensible to have it as the default strategy, seeing that the library simply fails horribly if it's used after fork with `NN_FORK_NONE`, but I thought that keeping the current behaviour would be less disrupting for existing programs that use `fork(2)` then `exec(2)`.
- I did the ground work for multiple fork strategies in the event that more than the two commited here would be added, but it might also not be justified.

If adding `nn_setopt` is OK, I will add a man page to cover it in `./doc`.

Last but not least, I added a test at `tests/fork.c` to test the behaviour of NN_FORK_RESET.
