### PR TITLE
Page-aligned chunk allocator

### DIFF
--- a/doc/nn_allocmsg.txt
+++ b/doc/nn_allocmsg.txt
@@ -26,7 +26,13 @@ default one, however, individual transport mechanisms may define their
 own allocation mechanisms, such as allocating in shared memory or allocating
 a memory block pinned down to a physical memory address. Such allocation,
 when used with the transport that defines them, should be more efficient
-than the default allocation mechanism.
+than the default allocation mechanism. Refer to the next section for more details.
+
+ALLOCATION TYPES
+----------------
+
+*NN_ALLOC_PAGEALIGN*::
+Allocate a chunk in a page-aligned memory address. This may improve performance on transports that benefit from memory alignment. If your system does not support aligned allocation this function will return 'ENOSYS'.
 
 
 RETURN VALUE
@@ -40,6 +46,8 @@ ERRORS
 ------
 *EINVAL*::
 Supplied allocation 'type' is invalid.
+*ENOSYS*::
+The specified allocation 'type' is not supported by your system.
 *ENOMEM*::
 Not enough memory to allocate the message.
 

--- a/src/nn.h
+++ b/src/nn.h
@@ -258,6 +258,9 @@ NN_EXPORT void nn_term (void);
 
 #define NN_MSG ((size_t) -1)
 
+/* Allocate memory aligned to page-size */
+#define NN_ALLOC_PAGEALIGN
+
 NN_EXPORT void *nn_allocmsg (size_t size, int type);
 NN_EXPORT void *nn_reallocmsg (void *msg, size_t size);
 NN_EXPORT int nn_freemsg (void *msg);

--- a/src/nn.h
+++ b/src/nn.h
@@ -2,6 +2,7 @@
     Copyright (c) 2012-2014 Martin Sustrik  All rights reserved.
     Copyright (c) 2013 GoPivotal, Inc.  All rights reserved.
     Copyright 2015 Garrett D'Amore <garrett@damore.org>
+    Copyright (c) 2016 Ioannis Charalampidis <ioannis.charalampidis@cern.ch>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -259,7 +260,7 @@ NN_EXPORT void nn_term (void);
 #define NN_MSG ((size_t) -1)
 
 /* Allocate memory aligned to page-size */
-#define NN_ALLOC_PAGEALIGN
+#define NN_ALLOC_PAGEALIGN 1
 
 NN_EXPORT void *nn_allocmsg (size_t size, int type);
 NN_EXPORT void *nn_reallocmsg (void *msg, size_t size);

--- a/src/utils/chunk.c
+++ b/src/utils/chunk.c
@@ -1,6 +1,7 @@
 /*
     Copyright (c) 2013 Martin Sustrik  All rights reserved.
     Copyright (c) 2014 Achille Roussel All rights reserved.
+    Copyright (c) 2016 Ioannis Charalampidis <ioannis.charalampidis@cern.ch>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),

--- a/src/utils/chunk.c
+++ b/src/utils/chunk.c
@@ -65,6 +65,7 @@ static size_t nn_chunk_hdrsize ();
 
 int nn_chunk_alloc (size_t size, int type, void **result)
 {
+    int ret;
     size_t sz, szempty;
     struct nn_chunk *self;
     const size_t hdrsz = nn_chunk_hdrsize ();
@@ -102,7 +103,7 @@ int nn_chunk_alloc (size_t size, int type, void **result)
                   sizeof(struct nn_chunk) + sizeof(uint32_t) + sizeof(uint32_t);
 
         /* Allocate memory */
-        ret = posix_memalign( &self, sysconf(_SC_PAGESIZE), sz + szempty );
+        ret = posix_memalign( (void**)&self, sysconf(_SC_PAGESIZE), sz + szempty );
         if (nn_slow( ret != 0 )) return -ret;
 #else
         return -ENOSYS;

--- a/src/utils/chunk.c
+++ b/src/utils/chunk.c
@@ -108,6 +108,7 @@ int nn_chunk_alloc (size_t size, int type, void **result)
 #else
         return -ENOSYS;
 #endif
+        break;
 
     default:
         return -EINVAL;


### PR DESCRIPTION
Since some more advanced transports (such as one using RDMA) require page-boundaries alignment, I thought it might be a good idea to have such support available in the core.

This commit introduces the `NN_ALLOC_PAGEALIGN` alloc type that can be used on any chunk operation in order to align the chunk's memory on page boundaries. For example:

``` c
void *msg = nn_allocmsg( 1024, NN_ALLOC_PAGEALIGN );
```

This function will return `-ENOSYS` if aligned-alloc is not supported by your system. Currently that's windows, OSX, and *nix platforms with older POSIX api. 

_NOTE: This will overlap with #612, however I wanted to make a stand-alone pull request in case it's of a general interest_
