### PR TITLE
fixes #622 Remove statistics socket

### DIFF
--- a/doc/nn_env.txt
+++ b/doc/nn_env.txt
@@ -30,46 +30,18 @@ NN_PRINT_ERRORS::
     error is clear and appear again (e.g. connection established then broken
     again).
 
-NN_PRINT_STATISTICS::
-    If set to a non-empty string nanomsg will print some statistics to stderr.
-    That's statistics is intended for debugging purposes only.
-
-NN_STATISTICS_SOCKET::
-    The nanomsg address to send statistics to. Nanomsg opens a NN_PUB socket
-    and sends statistics there. The data is sent using the ESTP protocol.
-
 
 NOTES
 -----
 
-The output of both debugging facilities (NN_PRINT_ERRORS, NN_PRINT_STATISTICS)
+The output of the debugging facility (NN_PRINT_ERRORS)
 is intended for reading by a human and a subject for change at any time (even
 after 1.0 release).
-
-The NN_STATISTICS_SOCKET facility is intended to be used by system
-administrators to debug network and application issues. The ESTP format is
-stable. But the nanomsg support of it is experimental and is subject to change
-or removal until 1.0 release.
-
-Anyway, there is *no excuse* for making application logic based on the data
-described here.  And by application logic we mean any of the following:
-
-* Load balancing
-* Failover
-* Routing requests
-* Executing nn_connect/nn_bind
-
-There are other ways for load-balancing and failover in nanomsg. If you feel
-you can't do something, consider asking on the mailing list first.
 
 
 SEE ALSO
 --------
 linknanomsg:nanomsg[7]
-
-http://github.com/estp
-
-http://github.com/estp/estp/blob/master/specification.rst
 
 
 AUTHORS


### PR DESCRIPTION
This removes both NN_PRINT_STATISTICS and NN_STATISTICS_SOCKET.  We have nn_get_statistic() as a formal API now.

This also fixes a couple of portability snafus.