### PR TITLE
fixes #625 Switch documentation formatting to asciidoctor

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -445,7 +445,7 @@ endif
 
 #  Extra files to be included into the source package.
 
-EXTRA_DIST += doc/colony.css $(MAN1) $(MAN3) $(MAN7)
+EXTRA_DIST += doc/stylesheet.css $(MAN1) $(MAN3) $(MAN7)
 
 ################################################################################
 #  performance tests                                                           #

--- a/Makefile.am
+++ b/Makefile.am
@@ -397,36 +397,34 @@ if DOC
 
 #  Build instructions.
 
-.txt.xml:
-	$(AM_V_GEN)$(ASCIIDOC) -d manpage -b docbook \
-        -f $(abs_srcdir)/doc/asciidoc.conf \
-        -aversion=@NN_PACKAGE_VERSION@ -o $@ $<
-
 SUFFIXES = .1 .3 .7 .1.html .3.html .7.html
-.xml.1:
-	$(AM_V_GEN)$(XMLTO) -o doc man $<
-.xml.3:
-	$(AM_V_GEN)$(XMLTO) -o doc man $<
-.xml.7:
-	$(AM_V_GEN)$(XMLTO) -o doc man $<
+.txt.1:
+	$(AM_V_GEN)$(ASCIIDOCTOR) -b manpage -D doc \
+	-amanmanual="nanomsg @NN_PACKAGE_VERSION@" $<
+.txt.3:
+	$(AM_V_GEN)$(ASCIIDOCTOR) -b manpage -D doc \
+	-amanmanual="nanomsg @NN_PACKAGE_VERSION@" $<
+.txt.7:
+	$(AM_V_GEN)$(ASCIIDOCTOR) -b manpage -D doc \
+	-amanmanual="nanomsg @NN_PACKAGE_VERSION@" $<
 
 .txt.1.html:
-	$(AM_V_GEN)$(ASCIIDOC) -d manpage -b xhtml11 \
-        -a stylesheet=$(abs_srcdir)/doc/htmldoc.css \
-        -f $(abs_srcdir)/doc/asciidoc.conf \
-        -aversion=@NN_PACKAGE_VERSION@ -o $@ $<
+	$(AM_V_GEN)$(ASCIIDOCTOR) -d manpage -b html5 \
+        -a stylesheet=$(abs_srcdir)/doc/stylesheet.css -atoc=left \
+        -a version-label=$(PACKAGE) -a revnumber=$(PACKAGE_VERSION) \
+        -o $@ $<
 
 .txt.3.html:
-	$(AM_V_GEN)$(ASCIIDOC) -d manpage -b xhtml11 \
-        -a stylesheet=$(abs_srcdir)/doc/htmldoc.css \
-        -f $(abs_srcdir)/doc/asciidoc.conf \
-        -aversion=@NN_PACKAGE_VERSION@ -o $@ $<
+	$(AM_V_GEN)$(ASCIIDOCTOR) -d manpage -b html5 \
+        -a stylesheet=$(abs_srcdir)/doc/stylesheet.css -atoc=left \
+        -a version-label=$(PACKAGE) -a revnumber=$(PACKAGE_VERSION) \
+        -o $@ $<
 
 .txt.7.html:
-	$(AM_V_GEN)$(ASCIIDOC) -d manpage -b xhtml11 \
-        -a stylesheet=$(abs_srcdir)/doc/htmldoc.css \
-        -f $(abs_srcdir)/doc/asciidoc.conf \
-        -aversion=@NN_PACKAGE_VERSION@ -o $@ $<
+	$(AM_V_GEN)$(ASCIIDOCTOR) -d manpage -b html5 \
+        -a stylesheet=$(abs_srcdir)/doc/stylesheet.css -atoc=left \
+        -a version-label=$(PACKAGE) -a revnumber=$(PACKAGE_VERSION) \
+        -o $@ $<
 
 #  Cause man pages to be generated and installed.
 
@@ -447,7 +445,7 @@ endif
 
 #  Extra files to be included into the source package.
 
-EXTRA_DIST += doc/asciidoc.conf doc/htmldoc.css $(MAN1) $(MAN3) $(MAN7)
+EXTRA_DIST += doc/colony.css $(MAN1) $(MAN3) $(MAN7)
 
 ################################################################################
 #  performance tests                                                           #

--- a/configure.ac
+++ b/configure.ac
@@ -173,20 +173,16 @@ AC_ARG_ENABLE([doc],
 )
 
 AS_IF([test x"$enable_doc" = "xyes"], [
-    AC_CHECK_PROGS([ASCIIDOC], [asciidoc])
-    AS_IF([test x"$ASCIIDOC" = "x"],[
-        AC_MSG_ERROR([Please install asciidoc to build the documentation])
-    ])
-    AC_CHECK_PROGS([XMLTO], [xmlto])
-    AS_IF([test x"$XMLTO" = "x"], [
-        AC_MSG_ERROR([Please install xmlto to build the documentation])
+    AC_CHECK_PROGS([ASCIIDOCTOR], [asciidoctor])
+    AS_IF([test x"$ASCIIDOCTOR" = "x"],[
+        AC_MSG_ERROR([Please install asciidoctor to build the documentation])
     ])
     AS_IF([test ! -d "doc"], [
         AC_PROG_MKDIR_P
         AS_MKDIR_P("doc")
     ])
 ])
-AM_CONDITIONAL([DOC], [test x"$ASCIIDOC" != "x" -a x"$XMLTO" != "x" ])
+AM_CONDITIONAL([DOC], [test x"$ASCIIDOCTOR" != "x"])
 
 ################################################################################
 #  Build nanocat                                                               #

--- a/doc/README
+++ b/doc/README
@@ -1,5 +1,7 @@
 This directory contains the documentation for nanomsg library. To build the
 documentation (both man pages and web pages) do "./configure --enable-doc" and
 "make" in the build directory; man pages will be installed with "make install".
-The prerequisites for building the documentation are asciidoc and xmlto
-utilities.
+You must have asciidoctor installed.
+
+The stylesheet.css file is taken from asciidoctor-stylesheet-factory, and
+is the colony theme.

--- a/doc/nanocat.txt
+++ b/doc/nanocat.txt
@@ -167,9 +167,9 @@ Send heartbeats to imaginary monitoring service:
 
 SEE ALSO
 --------
-linknanomsg:nanomsg[7]
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
 
-Paul Colomiets <paul@colomiets.name>
+link:mailto:paul@colomiets.name[Paul Colomiets]

--- a/doc/nanomsg.txt
+++ b/doc/nanomsg.txt
@@ -18,119 +18,119 @@ DESCRIPTION
 Following functions are exported by nanomsg library:
 
 Create an SP socket::
-    linknanomsg:nn_socket[3]
+    <<nn_socket.3.txt#,nn_socket(3)>>
 
 Close an SP socket::
-    linknanomsg:nn_close[3]
+    <<nn_close.3.txt#,nn_close(3)>>
 
 Set a socket option::
-    linknanomsg:nn_setsockopt[3]
+    <<nn_setsockopt.3.txt#,nn_setsockopt(3)>>
 
 Retrieve a socket option::
-    linknanomsg:nn_getsockopt[3]
+    <<nn_getsockopt.3.txt#,nn_getsockopt(3)>>
 
 Add a local endpoint to the socket::
-    linknanomsg:nn_bind[3]
+    <<nn_bind.3.txt#,nn_bind(3)>>
 
 Add a remote endpoint to the socket::
-    linknanomsg:nn_connect[3]
+    <<nn_connect.3.txt#,nn_connect(3)>>
 
 Remove an endpoint from the socket::
-    linknanomsg:nn_shutdown[3]
+    <<nn_shutdown.3.txt#,nn_shutdown(3)>>
 
 Send a message::
-    linknanomsg:nn_send[3]
+    <<nn_send.3.txt#,nn_send(3)>>
 
 Receive a message::
-    linknanomsg:nn_recv[3]
+    <<nn_recv.3.txt#,nn_recv(3)>>
 
 Fine-grained alternative to nn_send::
-    linknanomsg:nn_sendmsg[3]
+    <<nn_sendmsg.3.txt#,nn_sendmsg(3)>>
 
 Fine-grained alternative to nn_recv::
-    linknanomsg:nn_recvmsg[3]
+    <<nn_recvmsg.3.txt#,nn_recvmsg(3)>>
 
 Allocation of messages::
-    linknanomsg:nn_allocmsg[3]
-    linknanomsg:nn_reallocmsg[3]
-    linknanomsg:nn_freemsg[3]
+    <<nn_allocmsg.3.txt#,nn_allocmsg(3)>>
+    <<nn_reallocmsg.3.txt#,nn_reallocmsg(3)>>
+    <<nn_freemsg.3.txt#,nn_freemsg(3)>>
 
 Manipulation of message control data::
-    linknanomsg:nn_cmsg[3]
+    <<nn_cmsg.3.txt#,nn_cmsg(3)>>
 
 Multiplexing::
-    linknanomsg:nn_poll[3]
+    <<nn_poll.3.txt#,nn_poll(3)>>
 
 Retrieve the current errno::
-    linknanomsg:nn_errno[3]
+    <<nn_errno.3.txt#,nn_errno(3)>>
 
 Convert an error number into human-readable string::
-    linknanomsg:nn_strerror[3]
+    <<nn_strerror.3.txt#,nn_strerror(3)>>
 
 Query the names and values of nanomsg symbols::
-    linknanomsg:nn_symbol[3]
+    <<nn_symbol.3.txt#,nn_symbol(3)>>
 
 Query properties of nanomsg symbols::
-    linknanomsg:nn_symbol_info[3]
+    <<nn_symbol_info.3.txt#,nn_symbol_info(3)>>
 
 Query statistics on a socket::
-    linknanomsg:nn_get_statistic[3]
+    <<nn_get_statistic.3.txt#,nn_get_statistic(3)>>
 
 Start a device::
-    linknanomsg:nn_device[3]
+    <<nn_device.3.txt#,nn_device(3)>>
 
 Notify all sockets about process termination::
-    linknanomsg:nn_term[3]
+    <<nn_term.3.txt#,nn_term(3)>>
 
 Environment variables that influence nanomsg work::
-    linknanomsg:nn_env[7]
+    <<nn_env.7.txt#,nn_env(7)>>
 
 Following scalability protocols are provided by nanomsg:
 
 One-to-one protocol::
-    linknanomsg:nn_pair[7]
+    <<nn_pair.7.txt#,nn_pair(7)>>
 
 Request/reply protocol::
-    linknanomsg:nn_reqrep[7]
+    <<nn_reqrep.7.txt#,nn_reqrep(7)>>
 
 Publish/subscribe protocol::
-    linknanomsg:nn_pubsub[7]
+    <<nn_pubsub.7.txt#,nn_pubsub(7)>>
 
 Survey protocol::
-    linknanomsg:nn_survey[7]
+    <<nn_survey.7.txt#,nn_survey(7)>>
 
 Pipeline protocol::
-    linknanomsg:nn_pipeline[7]
+    <<nn_pipeline.7.txt#,nn_pipeline(7)>>
 
 Message bus protocol::
-    linknanomsg:nn_bus[7]
+    <<nn_bus.7.txt#,nn_bus(7)>>
 
 Following transport mechanisms are provided by nanomsg:
 
 In-process transport::
-    linknanomsg:nn_inproc[7]
+    <<nn_inproc.7.txt#,nn_inproc(7)>>
 
 Inter-process transport::
-    linknanomsg:nn_ipc[7]
+    <<nn_ipc.7.txt#,nn_ipc(7)>>
 
 TCP transport::
-    linknanomsg:nn_tcp[7]
+    <<nn_tcp.7.txt#,nn_tcp(7)>>
 
 TCPMUX transport::
-    linknanomsg:nn_tcpmux[7]
+    <<nn_tcpmux.7.txt#,nn_tcpmux(7)>>
 
 WebSocket transport::
-    linknanomsg:nn_ws[7]
+    <<nn_ws.7.txt#,nn_ws(7)>>
 
 Following tools are installed with the library:
 
 nanocat::
-    linknanomsg:nanocat[1]
+    <<nanocat.1.txt#,nanocat(1)>>
 
 tcpmuxd::
-    linknanomsg:tcpmuxd[1]
+    <<tcpmuxd.1.txt#,tcpmuxd(1)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_allocmsg.txt
+++ b/doc/nn_allocmsg.txt
@@ -17,7 +17,7 @@ DESCRIPTION
 -----------
 Allocate a message of the specified 'size' to be sent in zero-copy fashion.
 The content of the message is undefined after allocation and it should be filled
-in by the user. While linknanomsg:nn_send[3] and linknanomsg:nn_sendmsg[3] allow
+in by the user. While <<nn_send.3.txt#,nn_send(3)>> and <<nn_sendmsg.3.txt#,nn_sendmsg(3)>> allow
 to send arbitrary buffers, buffers allocated using _nn_allocmsg()_ can be more
 efficient for large messages as they allow for using zero-copy techniques.
 
@@ -56,13 +56,13 @@ nn_send (s, &buf, NN_MSG, 0);
 
 SEE ALSO
 --------
-linknanomsg:nn_freemsg[3]
-linknanomsg:nn_reallocmsg[3]
-linknanomsg:nn_send[3]
-linknanomsg:nn_sendmsg[3]
-linknanomsg:nanomsg[7]
+<<nn_freemsg.3.txt#,nn_freemsg(3)>>
+<<nn_reallocmsg.3.txt#,nn_reallocmsg(3)>>
+<<nn_send.3.txt#,nn_send(3)>>
+<<nn_sendmsg.3.txt#,nn_sendmsg(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_bind.txt
+++ b/doc/nn_bind.txt
@@ -23,19 +23,19 @@ The 'transport' specifies the underlying transport protocol to use. The meaning
 of the 'address' part is specific to the underlying transport protocol.
 
 For the list of available transport protocols check the list on
-linknanomsg:nanomsg[7] manual page.
+<<nanomsg.7.txt#,nanomsg(7)>> manual page.
 
 Maximum length of the 'addr' parameter is specified by _NN_SOCKADDR_MAX_
 defined in '<nanomsg/nn.h>' header file.
 
-Note that nn_bind and linknanomsg:nn_connect[3] may be called multiple times
+Note that nn_bind and <<nn_connect.3.txt#,nn_connect(3)>> may be called multiple times
 on the same socket thus allowing the socket to communicate with multiple
 heterogeneous endpoints.
 
 RETURN VALUE
 ------------
 If the function succeeds positive endpoint ID is returned. Endpoint ID can be
-later used to remove the endpoint from the socket via linknanomsg:nn_shutdown[3]
+later used to remove the endpoint from the socket via <<nn_shutdown.3.txt#,nn_shutdown(3)>>
 function.
 
 If the function fails, then -1 is returned and 'errno' is set to to one of
@@ -76,15 +76,15 @@ eid2 = nn_bind (s, "tcp://127.0.0.1:5560");
 
 SEE ALSO
 --------
-linknanomsg:nn_inproc[7]
-linknanomsg:nn_ipc[7]
-linknanomsg:nn_tcp[7]
-linknanomsg:nn_socket[3]
-linknanomsg:nn_connect[3]
-linknanomsg:nn_shutdown[3]
-linknanomsg:nanomsg[7]
+<<nn_inproc.7.txt#,nn_inproc(7)>>
+<<nn_ipc.7.txt#,nn_ipc(7)>>
+<<nn_tcp.7.txt#,nn_tcp(7)>>
+<<nn_socket.3.txt#,nn_socket(3)>>
+<<nn_connect.3.txt#,nn_connect(3)>>
+<<nn_shutdown.3.txt#,nn_shutdown(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_bus.txt
+++ b/doc/nn_bus.txt
@@ -44,14 +44,14 @@ There are no options defined at the moment.
 
 SEE ALSO
 --------
-linknanomsg:nn_pubsub[7]
-linknanomsg:nn_reqrep[7]
-linknanomsg:nn_pipeline[7]
-linknanomsg:nn_survey[7]
-linknanomsg:nn_pair[7]
-linknanomsg:nanomsg[7]
+<<nn_pubsub.7.txt#,nn_pubsub(7)>>
+<<nn_reqrep.7.txt#,nn_reqrep(7)>>
+<<nn_pipeline.7.txt#,nn_pipeline(7)>>
+<<nn_survey.7.txt#,nn_survey(7)>>
+<<nn_pair.7.txt#,nn_pair(7)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_close.txt
+++ b/doc/nn_close.txt
@@ -49,11 +49,11 @@ assert (rc == 0);
 
 SEE ALSO
 --------
-linknanomsg:nn_socket[3]
-linknanomsg:nn_setsockopt[3]
-linknanomsg:nanomsg[7]
+<<nn_socket.3.txt#,nn_socket(3)>>
+<<nn_setsockopt.3.txt#,nn_setsockopt(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_cmsg.txt
+++ b/doc/nn_cmsg.txt
@@ -32,7 +32,7 @@ Structure 'nn_cmsghdr' represents a single ancillary property and contains follo
     int cmsg_type;
 
 'cmsg_len' is the size of the property data, including the preceding nn_cmsghdr structure.
-'cmsg_level' is the level of the property; same values can be used as with linknanomsg:nn_getsockopt[3] and linknanomsg:nn_setsockopt[3].
+'cmsg_level' is the level of the property; same values can be used as with <<nn_getsockopt.3.txt#,nn_getsockopt(3)>> and <<nn_setsockopt.3.txt#,nn_setsockopt(3)>>.
 'cmsg_type' is the name of the property. These names are specific for each level.
 
 _NN_CMSG_FIRSTHDR_ returns a pointer to the first nn_cmsghdr in the control buffer in the supplied nn_msghdr structure.
@@ -71,14 +71,14 @@ while (hdr != NULL) {
 
 SEE ALSO
 --------
-linknanomsg:nn_sendmsg[3]
-linknanomsg:nn_recvmsg[3]
-linknanomsg:nn_getsockopt[3]
-linknanomsg:nn_setsockopt[3]
-linknanomsg:nanomsg[7]
+<<nn_sendmsg.3.txt#,nn_sendmsg(3)>>
+<<nn_recvmsg.3.txt#,nn_recvmsg(3)>>
+<<nn_getsockopt.3.txt#,nn_getsockopt(3)>>
+<<nn_setsockopt.3.txt#,nn_setsockopt(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_connect.txt
+++ b/doc/nn_connect.txt
@@ -23,19 +23,19 @@ The 'transport' specifies the underlying transport protocol to use. The meaning
 of the 'address' part is specific to the underlying transport protocol.
 
 For the list of available transport protocols check the list on
-linknanomsg:nanomsg[7] manual page.
+<<nanomsg.7.txt#,nanomsg(7)>> manual page.
 
 Maximum length of the 'addr' parameter is specified by _NN_SOCKADDR_MAX_
 defined in '<nanomsg/nn.h>' header file.
 
-Note that nn_connect and linknanomsg:nn_bind[3] may be called multiple times
+Note that nn_connect and <<nn_bind.3.txt#,nn_bind(3)>> may be called multiple times
 on the same socket thus allowing the socket to communicate with multiple
 heterogeneous endpoints.
 
 RETURN VALUE
 ------------
 If the function succeeds positive endpoint ID is returned. Endpoint ID can be
-later used to remove the endpoint from the socket via linknanomsg:nn_shutdown[3]
+later used to remove the endpoint from the socket via <<nn_shutdown.3.txt#,nn_shutdown(3)>>
 function.
 
 If the function fails negative value is returned and 'errno' is set to to one of
@@ -72,15 +72,15 @@ eid2 = nn_connect (s, "tcp://server001:5560");
 
 SEE ALSO
 --------
-linknanomsg:nn_inproc[7]
-linknanomsg:nn_ipc[7]
-linknanomsg:nn_tcp[7]
-linknanomsg:nn_socket[3]
-linknanomsg:nn_bind[3]
-linknanomsg:nn_shutdown[3]
-linknanomsg:nanomsg[7]
+<<nn_inproc.7.txt#,nn_inproc(7)>>
+<<nn_ipc.7.txt#,nn_ipc(7)>>
+<<nn_tcp.7.txt#,nn_tcp(7)>>
+<<nn_socket.3.txt#,nn_socket(3)>>
+<<nn_bind.3.txt#,nn_bind(3)>>
+<<nn_shutdown.3.txt#,nn_shutdown(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_device.txt
+++ b/doc/nn_device.txt
@@ -22,7 +22,7 @@ _nn_device_ works in a "loopback" mode -- it loops and sends any messages
 received from the socket back to itself.
 
 To break the loop and make _nn_device_ function exit use the
-linknanomsg:nn_term[3] function.
+<<nn_term.3.txt#,nn_term(3)>> function.
 
 RETURN VALUE
 ------------
@@ -56,12 +56,12 @@ nn_device (s1, s2);
 
 SEE ALSO
 --------
-linknanomsg:nn_socket[3]
-linknanomsg:nn_term[3]
-linknanomsg:nanomsg[7]
+<<nn_socket.3.txt#,nn_socket(3)>>
+<<nn_term.3.txt#,nn_term(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_env.txt
+++ b/doc/nn_env.txt
@@ -65,7 +65,7 @@ you can't do something, consider asking on the mailing list first.
 
 SEE ALSO
 --------
-linknanomsg:nanomsg[7]
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 http://github.com/estp
 
@@ -74,5 +74,5 @@ http://github.com/estp/estp/blob/master/specification.rst
 
 AUTHORS
 -------
-Paul Colomiets <paul@colomiets.name>
+link:mailto:paul@colomiets.name[Paul Colomiets]
 

--- a/doc/nn_errno.txt
+++ b/doc/nn_errno.txt
@@ -48,10 +48,10 @@ if (rc < 0)
 
 SEE ALSO
 --------
-linknanomsg:nn_strerror[3]
-linknanomsg:nanomsg[7]
+<<nn_strerror.3.txt#,nn_strerror(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_freemsg.txt
+++ b/doc/nn_freemsg.txt
@@ -15,9 +15,9 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Deallocates a message allocated using linknanomsg:nn_allocmsg[3] function or
-received via linknanomsg:nn_recv[3] or linknanomsg:nn_recvmsg[3] function.
-While linknanomsg:nn_recv[3] and linknanomsg:nn_recvmsg[3] allow to receive data
+Deallocates a message allocated using <<nn_allocmsg.3.txt#,nn_allocmsg(3)>> function or
+received via <<nn_recv.3.txt#,nn_recv(3)>> or <<nn_recvmsg.3.txt#,nn_recvmsg(3)>> function.
+While <<nn_recv.3.txt#,nn_recv(3)>> and <<nn_recvmsg.3.txt#,nn_recvmsg(3)>> allow to receive data
 into arbitrary buffers, using library-allocated buffers can be more
 efficient for large messages as it allows for using zero-copy techniques.
 
@@ -46,13 +46,13 @@ nn_freemsg (buf);
 
 SEE ALSO
 --------
-linknanomsg:nn_allocmsg[3]
-linknanomsg:nn_reallocmsg[3]
-linknanomsg:nn_recv[3]
-linknanomsg:nn_recvmsg[3]
-linknanomsg:nanomsg[7]
+<<nn_allocmsg.3.txt#,nn_allocmsg(3)>>
+<<nn_reallocmsg.3.txt#,nn_reallocmsg(3)>>
+<<nn_recv.3.txt#,nn_recv(3)>>
+<<nn_recvmsg.3.txt#,nn_recvmsg(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_get_statistic.txt
+++ b/doc/nn_get_statistic.txt
@@ -15,19 +15,20 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Retrieves the value of the statistic from the socket.
+Retrieves the value of a statistic from the socket.
 
-While this API is stable, these statistics are intended for human consumption,
-to facilitate observability and debugging.  The actual statistics themselves
-as well as their meanings are unstable, and subject to change without notice.
+CAUTION: While this API is stable, these statistics are intended for
+human consumption, to facilitate observability and debugging.
+The actual statistics themselves as well as their meanings are unstable,
+and subject to change without notice.
 Programs should not depend on the presence or values of any particular
 statistic.
 
-While the following statistics are maintained by the nanomsg core framework,
+The following statistics are maintained by the nanomsg core framework;
 others may be present. As those are undocumented, no interpretration should
 be made from them. Not all statistics are relevant to all transports.
-For example, the inproc transport does not maintain any
-of the connection related statistics.
+For example, the <<nn_inproc.7.txt#,nn_inproc(7)>> transport does not
+maintain any of the connection related statistics.
 
 
 *NN_STAT_ESTABLISHED_CONNECTIONS*::
@@ -82,19 +83,19 @@ EXAMPLE
 -------
 
 ----
-val = nn_get_staistic (s, NN_STAT_SENT_MESSAGES);
+val = nn_get_statistic (s, NN_STAT_SENT_MESSAGES);
 if (val == 0)
     printf ("No messages have been sent yet.\n");
 ----
 
 SEE ALSO
 --------
-linknanomsg:nn_errno[3]
-linknanomsg:nn_symbol[3]
-linknanomsg:nanomsg[7]
+<<nn_errno.3.txt#,nn_errno(3)>>
+<<nn_symbol.3.txt#,nn_symbol(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Garrett D'Amore <garrett@damore.org>
+link:mailto:garrett@damore.org[Garrett D'Amore]
 

--- a/doc/nn_getsockopt.txt
+++ b/doc/nn_getsockopt.txt
@@ -111,7 +111,7 @@ _<nanomsg/nn.h>_ header defines generic socket-level options
 *NN_SOCKET_NAME*::
     Socket name for error reporting and statistics. The type of the option
     is string. Default value is "N" where N is socket integer.
-    *This option is experimental, see linknanomsg:nn_env[7] for details*
+    *This option is experimental, see <<nn_env.7.txt#,nn_env(7)>> for details*
 
 
 RETURN VALUE
@@ -141,11 +141,11 @@ nn_getsockopt (s, NN_SOL_SOCKET, NN_LINGER, &linger, &sz);
 
 SEE ALSO
 --------
-linknanomsg:nn_socket[3]
-linknanomsg:nn_setsockopt[3]
-linknanomsg:nanomsg[7]
+<<nn_socket.3.txt#,nn_socket(3)>>
+<<nn_setsockopt.3.txt#,nn_setsockopt(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_inproc.txt
+++ b/doc/nn_inproc.txt
@@ -44,13 +44,13 @@ nn_connect (s2, "inproc://test);
 
 SEE ALSO
 --------
-linknanomsg:nn_ipc[7]
-linknanomsg:nn_tcp[7]
-linknanomsg:nn_bind[3]
-linknanomsg:nn_connect[3]
-linknanomsg:nanomsg[7]
+<<nn_ipc.7.txt#,nn_ipc(7)>>
+<<nn_tcp.7.txt#,nn_tcp(7)>>
+<<nn_bind.3.txt#,nn_bind(3)>>
+<<nn_connect.3.txt#,nn_connect(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]

--- a/doc/nn_ipc.txt
+++ b/doc/nn_ipc.txt
@@ -39,13 +39,13 @@ nn_connect (s2, "ipc:///tmp/test.ipc");
 
 SEE ALSO
 --------
-linknanomsg:nn_inproc[7]
-linknanomsg:nn_tcp[7]
-linknanomsg:nn_bind[3]
-linknanomsg:nn_connect[3]
-linknanomsg:nanomsg[7]
+<<nn_inproc.7.txt#,nn_inproc(7)>>
+<<nn_tcp.7.txt#,nn_tcp(7)>>
+<<nn_bind.3.txt#,nn_bind(3)>>
+<<nn_connect.3.txt#,nn_connect(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]

--- a/doc/nn_pair.txt
+++ b/doc/nn_pair.txt
@@ -34,7 +34,7 @@ Socket Types
 NN_PAIR::
     Socket for communication with exactly one peer. Each party can send messages
     at any time. If the peer is not available or send buffer is full subsequent
-    calls to linknanomsg:nn_send[3] will block until it's possible to send the
+    calls to <<nn_send.3.txt#,nn_send(3)>> will block until it's possible to send the
     message.
 
 Socket Options
@@ -44,15 +44,15 @@ No protocol-specific socket options are defined at the moment.
 
 SEE ALSO
 --------
-linknanomsg:nn_bus[7]
-linknanomsg:nn_pubsub[7]
-linknanomsg:nn_reqrep[7]
-linknanomsg:nn_pipeline[7]
-linknanomsg:nn_survey[7]
-linknanomsg:nanomsg[7]
+<<nn_bus.7.txt#,nn_bus(7)>>
+<<nn_pubsub.7.txt#,nn_pubsub(7)>>
+<<nn_reqrep.7.txt#,nn_reqrep(7)>>
+<<nn_pipeline.7.txt#,nn_pipeline(7)>>
+<<nn_survey.7.txt#,nn_survey(7)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_pipeline.txt
+++ b/doc/nn_pipeline.txt
@@ -35,15 +35,15 @@ No protocol-specific socket options are defined at the moment.
 
 SEE ALSO
 --------
-linknanomsg:nn_bus[7]
-linknanomsg:nn_pubsub[7]
-linknanomsg:nn_reqrep[7]
-linknanomsg:nn_survey[7]
-linknanomsg:nn_pair[7]
-linknanomsg:nanomsg[7]
+<<nn_bus.7.txt#,nn_bus(7)>>
+<<nn_pubsub.7.txt#,nn_pubsub(7)>>
+<<nn_reqrep.7.txt#,nn_reqrep(7)>>
+<<nn_survey.7.txt#,nn_survey(7)>>
+<<nn_pair.7.txt#,nn_pair(7)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_poll.txt
+++ b/doc/nn_poll.txt
@@ -100,11 +100,11 @@ if (pfd [0].revents & NN_POLLIN) {
 
 SEE ALSO
 --------
-linknanomsg:nn_socket[3]
-linknanomsg:nn_getsockopt[3]
-linknanomsg:nanomsg[7]
+<<nn_socket.3.txt#,nn_socket(3)>>
+<<nn_getsockopt.3.txt#,nn_getsockopt(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_pubsub.txt
+++ b/doc/nn_pubsub.txt
@@ -90,14 +90,14 @@ nbytes = nn_recv(sub, &buf, NN_MSG, 0);
 
 SEE ALSO
 --------
-linknanomsg:nn_bus[7]
-linknanomsg:nn_reqrep[7]
-linknanomsg:nn_pipeline[7]
-linknanomsg:nn_survey[7]
-linknanomsg:nn_pair[7]
-linknanomsg:nanomsg[7]
+<<nn_bus.7.txt#,nn_bus(7)>>
+<<nn_reqrep.7.txt#,nn_reqrep(7)>>
+<<nn_pipeline.7.txt#,nn_pipeline(7)>>
+<<nn_survey.7.txt#,nn_survey(7)>>
+<<nn_pair.7.txt#,nn_pair(7)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_reallocmsg.txt
+++ b/doc/nn_reallocmsg.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Reallocate a message previously allocated by linknanomsg:nn_allocmsg[3] or
+Reallocate a message previously allocated by <<nn_allocmsg.3.txt#,nn_allocmsg(3)>> or
 received from a peer using NN_MSG mechanism.
 
 Note that as with the standard _realloc_, the operation may involve copying
@@ -46,11 +46,11 @@ nn_freemsg (newbuf);
 
 SEE ALSO
 --------
-linknanomsg:nn_allocmsg[3]
-linknanomsg:nn_freemsg[3]
-linknanomsg:nanomsg[7]
+<<nn_allocmsg.3.txt#,nn_allocmsg(3)>>
+<<nn_freemsg.3.txt#,nn_freemsg(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_recv.txt
+++ b/doc/nn_recv.txt
@@ -23,7 +23,7 @@ Alternatively, _nanomsg_ can allocate the buffer for you. To do so,
 let the 'buf' parameter be a pointer to a void* variable (pointer to pointer)
 to the receive buffer and set the 'len' parameter to _NN_MSG_. If the call is
 successful the user is responsible for deallocating the message using
-the linknanomsg:nn_freemsg[3] function.
+the <<nn_freemsg.3.txt#,nn_freemsg(3)>> function.
 
 The 'flags' argument is a combination of the flags defined below:
 
@@ -79,7 +79,7 @@ Receiving a message into a buffer allocated by _nanomsg_::
 The following will get a message from the pipe with a buffer allocated by
 the system. It is large enough to accommodate the entire message. This is a good
 way to get the entire message without truncating if the size of the message is
-unknown. It is the user's responsibility to call linknanomsg:nn_freemsg[3] after
+unknown. It is the user's responsibility to call <<nn_freemsg.3.txt#,nn_freemsg(3)>> after
 processing the message.
 
 ----
@@ -102,12 +102,12 @@ it is a zero-copy operation.
 
 SEE ALSO
 --------
-linknanomsg:nn_send[3]
-linknanomsg:nn_recvmsg[3]
-linknanomsg:nn_socket[3]
-linknanomsg:nanomsg[7]
+<<nn_send.3.txt#,nn_send(3)>>
+<<nn_recvmsg.3.txt#,nn_recvmsg(3)>>
+<<nn_socket.3.txt#,nn_socket(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_recvmsg.txt
+++ b/doc/nn_recvmsg.txt
@@ -33,7 +33,7 @@ the size of the array.
 the received message. 'msg_controllen' specifies the length of the buffer.
 If the control information should not be retrieved, set 'msg_control' parameter
 to NULL. For detailed discussion of how to parse the control information check
-linknanomsg:nn_cmsg[3] man page.
+<<nn_cmsg.3.txt#,nn_cmsg(3)>> man page.
 
 Structure 'nn_iovec' defines one element in the gather array (a buffer to be
 filled in by message data) and contains following members:
@@ -44,7 +44,7 @@ filled in by message data) and contains following members:
 Alternatively, _nanomsg_ library can allocate the buffer for you. To do so,
 let the 'iov_base' point to void* variable to receive the buffer and set
 'iov_len' to _NN_MSG_. After successful completion user is responsible
-for deallocating the message using linknanomsg:nn_freemsg[3] function. Gather
+for deallocating the message using <<nn_freemsg.3.txt#,nn_freemsg(3)>> function. Gather
 array in _nn_msghdr_ structure can contain only one element in this case.
 
 The 'flags' argument is a combination of the flags defined below:
@@ -104,15 +104,15 @@ nn_recvmsg (s, &hdr, 0);
 
 SEE ALSO
 --------
-linknanomsg:nn_recv[3]
-linknanomsg:nn_sendmsg[3]
-linknanomsg:nn_allocmsg[3]
-linknanomsg:nn_freemsg[3]
-linknanomsg:nn_cmsg[3]
-linknanomsg:nanomsg[7]
+<<nn_recv.3.txt#,nn_recv(3)>>
+<<nn_sendmsg.3.txt#,nn_sendmsg(3)>>
+<<nn_allocmsg.3.txt#,nn_allocmsg(3)>>
+<<nn_freemsg.3.txt#,nn_freemsg(3)>>
+<<nn_cmsg.3.txt#,nn_cmsg(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_reqrep.txt
+++ b/doc/nn_reqrep.txt
@@ -56,15 +56,15 @@ NN_REQ_RESEND_IVL::
 
 SEE ALSO
 --------
-linknanomsg:nn_bus[7]
-linknanomsg:nn_pubsub[7]
-linknanomsg:nn_pipeline[7]
-linknanomsg:nn_survey[7]
-linknanomsg:nn_pair[7]
-linknanomsg:nanomsg[7]
+<<nn_bus.7.txt#,nn_bus(7)>>
+<<nn_pubsub.7.txt#,nn_pubsub(7)>>
+<<nn_pipeline.7.txt#,nn_pipeline(7)>>
+<<nn_survey.7.txt#,nn_survey(7)>>
+<<nn_pair.7.txt#,nn_pair(7)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_send.txt
+++ b/doc/nn_send.txt
@@ -17,7 +17,7 @@ DESCRIPTION
 The function will send a message containing the data from buffer pointed to
 by 'buf' parameter to the socket 's'. The message will be 'len' bytes long.
 
-Alternatively, to send a buffer allocated by linknanomsg:nn_allocmsg[3] function
+Alternatively, to send a buffer allocated by <<nn_allocmsg.3.txt#,nn_allocmsg(3)>> function
 set the buf parameter to point to the pointer to the buffer and 'len' parameter
 to _NN_MSG_ constant. In this case a successful call to _nn_send_ will
 deallocate the buffer. Trying to deallocate it afterwards will result in
@@ -87,12 +87,12 @@ assert (nbytes == 3);
 
 SEE ALSO
 --------
-linknanomsg:nn_recv[3]
-linknanomsg:nn_sendmsg[3]
-linknanomsg:nn_socket[3]
-linknanomsg:nanomsg[7]
+<<nn_recv.3.txt#,nn_recv(3)>>
+<<nn_sendmsg.3.txt#,nn_sendmsg(3)>>
+<<nn_socket.3.txt#,nn_socket(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_sendmsg.txt
+++ b/doc/nn_sendmsg.txt
@@ -33,7 +33,7 @@ the size of the array.
 associated with the message being sent. 'msg_controllen' specifies the length
 of the buffer. If there's no control information to send, 'msg_control' should
 be set to NULL. For detailed discussion of how to set control data check
-linknanomsg:nn_cmsg[3] man page.
+<<nn_cmsg.3.txt#,nn_cmsg(3)>> man page.
 
 Structure 'nn_iovec' defines one element in the scatter array (i.e. a buffer
 to send to the socket) and contains following members:
@@ -41,7 +41,7 @@ to send to the socket) and contains following members:
     void *iov_base;
     size_t iov_len;
 
-Alternatively, to send a buffer allocated by linknanomsg:nn_allocmsg[3] function
+Alternatively, to send a buffer allocated by <<nn_allocmsg.3.txt#,nn_allocmsg(3)>> function
 set 'iov_base' to point to the pointer to the buffer and 'iov_len' to _NN_MSG_
 constant. In this case a successful call to _nn_sendmsg_ will deallocate the
 buffer. Trying to deallocate it afterwards will result in undefined behaviour.
@@ -137,15 +137,15 @@ nn_sendmsg (s, &hdr, 0);
 
 SEE ALSO
 --------
-linknanomsg:nn_send[3]
-linknanomsg:nn_recvmsg[3]
-linknanomsg:nn_allocmsg[3]
-linknanomsg:nn_freemsg[3]
-linknanomsg:nn_cmsg[3]
-linknanomsg:nanomsg[7]
+<<nn_send.3.txt#,nn_send(3)>>
+<<nn_recvmsg.3.txt#,nn_recvmsg(3)>>
+<<nn_allocmsg.3.txt#,nn_allocmsg(3)>>
+<<nn_freemsg.3.txt#,nn_freemsg(3)>>
+<<nn_cmsg.3.txt#,nn_cmsg(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_setsockopt.txt
+++ b/doc/nn_setsockopt.txt
@@ -89,7 +89,7 @@ _<nanomsg/nn.h>_ header defines generic socket-level options
 *NN_SOCKET_NAME*::
     Socket name for error reporting and statistics. The type of the option
     is string. Default value is "socket.N" where N is socket integer.
-    *This option is experimental, see linknanomsg:nn_env[7] for details*
+    *This option is experimental, see <<nn_env.7.txt#,nn_env(7)>> for details*
 
 
 RETURN VALUE
@@ -121,11 +121,11 @@ nn_setsockopt (s, NN_SUB, NN_SUB_SUBSCRIBE, "ABC", 3);
 
 SEE ALSO
 --------
-linknanomsg:nn_socket[3]
-linknanomsg:nn_getsockopt[3]
-linknanomsg:nanomsg[7]
+<<nn_socket.3.txt#,nn_socket(3)>>
+<<nn_getsockopt.3.txt#,nn_getsockopt(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_shutdown.txt
+++ b/doc/nn_shutdown.txt
@@ -16,8 +16,8 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Removes an endpoint from socket 's'. 'how' parameter specifies the ID of the
-endpoint to remove as returned by prior call to linknanomsg:nn_bind[3] or
-linknanomsg:nn_connect[3]. _nn_shutdown()_ call will return immediately,
+endpoint to remove as returned by prior call to <<nn_bind.3.txt#,nn_bind(3)>> or
+<<nn_connect.3.txt#,nn_connect(3)>>. _nn_shutdown()_ call will return immediately,
 however, the library will try to deliver any outstanding outbound messages to
 the endpoint for the time specified by _NN_LINGER_ socket option.
 
@@ -53,12 +53,12 @@ nn_shutdown (s, eid);
 
 SEE ALSO
 --------
-linknanomsg:nn_socket[3]
-linknanomsg:nn_bind[3]
-linknanomsg:nn_connect[3]
-linknanomsg:nanomsg[7]
+<<nn_socket.3.txt#,nn_socket(3)>>
+<<nn_bind.3.txt#,nn_bind(3)>>
+<<nn_connect.3.txt#,nn_connect(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_socket.txt
+++ b/doc/nn_socket.txt
@@ -33,7 +33,7 @@ protocols to get the list of available socket types.
 
 The newly created socket is initially not associated with any endpoints.
 In order to establish a message flow at least one endpoint has to be added
-to the socket using linknanomsg:nn_bind[3] or linknanomsg:nn_connect[3]
+to the socket using <<nn_bind.3.txt#,nn_bind(3)>> or <<nn_connect.3.txt#,nn_connect(3)>>
 function.
 
 Also note that 'type' argument as found in standard _socket(2)_ function is
@@ -76,17 +76,17 @@ assert (s >= 0);
 
 SEE ALSO
 --------
-linknanomsg:nn_pubsub[7]
-linknanomsg:nn_reqrep[7]
-linknanomsg:nn_pipeline[7]
-linknanomsg:nn_survey[7]
-linknanomsg:nn_bus[7]
-linknanomsg:nn_bind[3]
-linknanomsg:nn_connect[3]
-linknanomsg:nn_close[3]
-linknanomsg:nanomsg[7]
+<<nn_pubsub.7.txt#,nn_pubsub(7)>>
+<<nn_reqrep.7.txt#,nn_reqrep(7)>>
+<<nn_pipeline.7.txt#,nn_pipeline(7)>>
+<<nn_survey.7.txt#,nn_survey(7)>>
+<<nn_bus.7.txt#,nn_bus(7)>>
+<<nn_bind.3.txt#,nn_bind(3)>>
+<<nn_connect.3.txt#,nn_connect(3)>>
+<<nn_close.3.txt#,nn_close(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_strerror.txt
+++ b/doc/nn_strerror.txt
@@ -41,12 +41,12 @@ if (rc < 0)
 
 SEE ALSO
 --------
-linknanomsg:nn_errno[3]
-linknanomsg:nn_symbol[3]
-linknanomsg:nanomsg[7]
+<<nn_errno.3.txt#,nn_errno(3)>>
+<<nn_symbol.3.txt#,nn_symbol(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_survey.txt
+++ b/doc/nn_survey.txt
@@ -43,15 +43,15 @@ NN_SURVEYOR_DEADLINE::
 
 SEE ALSO
 --------
-linknanomsg:nn_bus[7]
-linknanomsg:nn_pubsub[7]
-linknanomsg:nn_reqrep[7]
-linknanomsg:nn_pipeline[7]
-linknanomsg:nn_pair[7]
-linknanomsg:nanomsg[7]
+<<nn_bus.7.txt#,nn_bus(7)>>
+<<nn_pubsub.7.txt#,nn_pubsub(7)>>
+<<nn_reqrep.7.txt#,nn_reqrep(7)>>
+<<nn_pipeline.7.txt#,nn_pipeline(7)>>
+<<nn_pair.7.txt#,nn_pair(7)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_symbol.txt
+++ b/doc/nn_symbol.txt
@@ -63,12 +63,12 @@ for (i = 0; ; ++i) {
 
 SEE ALSO
 --------
-linknanomsg:nn_symbol_info[3]
-linknanomsg:nn_errno[3]
-linknanomsg:nn_strerror[3]
-linknanomsg:nanomsg[7]
+<<nn_symbol_info.3.txt#,nn_symbol_info(3)>>
+<<nn_errno.3.txt#,nn_errno(3)>>
+<<nn_strerror.3.txt#,nn_strerror(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Evan Wies <evan@neomantra.net>
+link:mailto:evan@neomantra.net[Evan Wies]

--- a/doc/nn_symbol_info.txt
+++ b/doc/nn_symbol_info.txt
@@ -143,13 +143,13 @@ for (i = 0; ; ++i) {
 
 SEE ALSO
 --------
-linknanomsg:nn_symbol[3]
-linknanomsg:nn_errno[3]
-linknanomsg:nn_strerror[3]
-linknanomsg:nanomsg[7]
+<<nn_symbol.3.txt#,nn_symbol(3)>>
+<<nn_errno.3.txt#,nn_errno(3)>>
+<<nn_strerror.3.txt#,nn_strerror(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Paul Colomiets <paul@colomiets.name>
-Garrett D'Amore <garrett@damore.org>
+link:mailto:paul@colomiets.name[Paul Colomiets]
+link:mailto:garrett@damore.org[Garrett D'Amore]

--- a/doc/nn_tcp.txt
+++ b/doc/nn_tcp.txt
@@ -64,14 +64,14 @@ nn_connect (s2, "tcp://myserver:5555");
 
 SEE ALSO
 --------
-linknanomsg:nn_inproc[7]
-linknanomsg:nn_ipc[7]
-linknanomsg:nn_bind[3]
-linknanomsg:nn_connect[3]
-linknanomsg:nanomsg[7]
+<<nn_inproc.7.txt#,nn_inproc(7)>>
+<<nn_ipc.7.txt#,nn_ipc(7)>>
+<<nn_bind.3.txt#,nn_bind(3)>>
+<<nn_connect.3.txt#,nn_connect(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_tcpmux.txt
+++ b/doc/nn_tcpmux.txt
@@ -20,7 +20,7 @@ THIS IS AN EXPERIMENTAL FEATURE. DO NOT USE.
 THE FUNCTIONALITY IS SUBJECT TO CHANGE WITHOUT PRIOR NOTICE.
 
 TCPMUX transport is basically the same as TCP transport
-(see linknanomsg:nn_tcp[7]) except that it allows to specify service names
+(see <<nn_tcp.7.txt#,nn_tcp(7)>>) except that it allows to specify service names
 along with IP addresses and TCP ports. What it means in practice is that many
 applications on the same box can share the same TCP port.
 
@@ -33,7 +33,7 @@ with a slash and a service name:
 nn_connect (s, "tcpmux://192.168.0.1:5555/foo");
 ----
 
-When binding to a TCPMUX endpoint, linknanomsg:nn_tcpmuxd[1] daemon must be
+When binding to a TCPMUX endpoint, <<nn_tcpmuxd.1.txt#,nn_tcpmuxd(1)>> daemon must be
 running on the box and specified port. There is no such requirement when
 connecting to a TCPMUX endpoint.
 
@@ -57,16 +57,16 @@ nn_connect (s2, "tcpmux://server1.example.org:5555/foo");
 
 SEE ALSO
 --------
-linknanomsg:nn_tcpmuxd[1]
-linknanomsg:nn_tcp[7]
-linknanomsg:nn_inproc[7]
-linknanomsg:nn_ipc[7]
-linknanomsg:nn_bind[3]
-linknanomsg:nn_connect[3]
-linknanomsg:nanomsg[7]
+<<nn_tcpmuxd.1.txt#,nn_tcpmuxd(1)>>
+<<nn_tcp.7.txt#,nn_tcp(7)>>
+<<nn_inproc.7.txt#,nn_inproc(7)>>
+<<nn_ipc.7.txt#,nn_ipc(7)>>
+<<nn_bind.3.txt#,nn_bind(3)>>
+<<nn_connect.3.txt#,nn_connect(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_term.txt
+++ b/doc/nn_term.txt
@@ -20,9 +20,9 @@ _nn_term()_ function which informs all the open sockets that process
 termination is underway.
 
 If a socket is blocked inside a blocking function, such as
-linknanomsg:nn_recv[3], it will be unblocked  and ETERM error will be returned
+<<nn_recv.3.txt#,nn_recv(3)>>, it will be unblocked  and ETERM error will be returned
 to the user. Similarly, any subsequent attempt to invoke a socket function other
-than linknanomsg:nn_close[3] after _nn_term()_ was called will result
+than <<nn_close.3.txt#,nn_close(3)>> after _nn_term()_ was called will result
 in ETERM error.
 
 If waiting for _NN_SNDFD_ or _NN_RCVFD_ using a polling function, such as
@@ -45,14 +45,14 @@ assert (rc == -1 && errno == ETERM);
 
 SEE ALSO
 --------
-linknanomsg:nn_close[3]
-linknanomsg:nn_send[3]
-linknanomsg:nn_recv[3]
-linknanomsg:nn_getsockopt[3]
-linknanomsg:nanomsg[7]
+<<nn_close.3.txt#,nn_close(3)>>
+<<nn_send.3.txt#,nn_send(3)>>
+<<nn_recv.3.txt#,nn_recv(3)>>
+<<nn_getsockopt.3.txt#,nn_getsockopt(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 

--- a/doc/nn_ws.txt
+++ b/doc/nn_ws.txt
@@ -16,7 +16,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-THIS IS AN EXPERIMENTAL FEATURE. DO NOT USE.
+WARNING: THIS IS AN EXPERIMENTAL FEATURE. DO NOT USE.
 THE FUNCTIONALITY IS SUBJECT TO CHANGE WITHOUT PRIOR NOTICE.
 
 When calling either `nn_bind()` or `nn_connect()`, omitting the port defaults
@@ -80,16 +80,16 @@ nn_connect (s2, "ws://myserver:5555");
 
 SEE ALSO
 --------
-linknanomsg:nn_tcp[7]
-linknanomsg:nn_inproc[7]
-linknanomsg:nn_ipc[7]
-linknanomsg:nn_bind[3]
-linknanomsg:nn_connect[3]
-linknanomsg:nanomsg[7]
+<<nn_tcp.7.txt#,nn_tcp(7)>>
+<<nn_inproc.7.txt#,nn_inproc(7)>>
+<<nn_ipc.7.txt#,nn_ipc(7)>>
+<<nn_bind.3.txt#,nn_bind(3)>>
+<<nn_connect.3.txt#,nn_connect(3)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 
 AUTHORS
 -------
-Martin Sustrik <sustrik@250bpm.com>
-Jack R. Dunaway <jack@wirebirdlabs.com>
-Garrett D'Amore <garrett@damore.org>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
+link:mailto:jack@wirebirdlabs.com[Jack R. Dunaway]
+link:mailto:garrett@damore.org[Garrett D'Amore]

--- a/doc/stylesheet.css
+++ b/doc/stylesheet.css
@@ -1,0 +1,691 @@
+/*! normalize.css v2.1.2 | MIT License | git.io/normalize */
+/* ========================================================================== HTML5 display definitions ========================================================================== */
+/** Correct `block` display not defined in IE 8/9. */
+article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary { display: block; }
+
+/** Correct `inline-block` display not defined in IE 8/9. */
+audio, canvas, video { display: inline-block; }
+
+/** Prevent modern browsers from displaying `audio` without controls. Remove excess height in iOS 5 devices. */
+audio:not([controls]) { display: none; height: 0; }
+
+/** Address `[hidden]` styling not present in IE 8/9. Hide the `template` element in IE, Safari, and Firefox < 22. */
+[hidden], template { display: none; }
+
+script { display: none !important; }
+
+/* ========================================================================== Base ========================================================================== */
+/** 1. Set default font family to sans-serif. 2. Prevent iOS text size adjust after orientation change, without disabling user zoom. */
+html { font-family: sans-serif; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ }
+
+/** Remove default margin. */
+body { margin: 0; }
+
+/* ========================================================================== Links ========================================================================== */
+/** Remove the gray background color from active links in IE 10. */
+a { background: transparent; }
+
+/** Address `outline` inconsistency between Chrome and other browsers. */
+a:focus { outline: thin dotted; }
+
+/** Improve readability when focused and also mouse hovered in all browsers. */
+a:active, a:hover { outline: 0; }
+
+/* ========================================================================== Typography ========================================================================== */
+/** Address variable `h1` font-size and margin within `section` and `article` contexts in Firefox 4+, Safari 5, and Chrome. */
+h1 { font-size: 2em; margin: 0.67em 0; }
+
+/** Address styling not present in IE 8/9, Safari 5, and Chrome. */
+abbr[title] { border-bottom: 1px dotted; }
+
+/** Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome. */
+b, strong { font-weight: bold; }
+
+/** Address styling not present in Safari 5 and Chrome. */
+dfn { font-style: italic; }
+
+/** Address differences between Firefox and other browsers. */
+hr { -moz-box-sizing: content-box; box-sizing: content-box; height: 0; }
+
+/** Address styling not present in IE 8/9. */
+mark { background: #ff0; color: #000; }
+
+/** Correct font family set oddly in Safari 5 and Chrome. */
+code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
+
+/** Improve readability of pre-formatted text in all browsers. */
+pre { white-space: pre-wrap; }
+
+/** Set consistent quote types. */
+q { quotes: "\201C" "\201D" "\2018" "\2019"; }
+
+/** Address inconsistent and variable font size in all browsers. */
+small { font-size: 80%; }
+
+/** Prevent `sub` and `sup` affecting `line-height` in all browsers. */
+sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
+
+sup { top: -0.5em; }
+
+sub { bottom: -0.25em; }
+
+/* ========================================================================== Embedded content ========================================================================== */
+/** Remove border when inside `a` element in IE 8/9. */
+img { border: 0; }
+
+/** Correct overflow displayed oddly in IE 9. */
+svg:not(:root) { overflow: hidden; }
+
+/* ========================================================================== Figures ========================================================================== */
+/** Address margin not present in IE 8/9 and Safari 5. */
+figure { margin: 0; }
+
+/* ========================================================================== Forms ========================================================================== */
+/** Define consistent border, margin, and padding. */
+fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
+
+/** 1. Correct `color` not being inherited in IE 8/9. 2. Remove padding so people aren't caught out if they zero out fieldsets. */
+legend { border: 0; /* 1 */ padding: 0; /* 2 */ }
+
+/** 1. Correct font family not being inherited in all browsers. 2. Correct font size not being inherited in all browsers. 3. Address margins set differently in Firefox 4+, Safari 5, and Chrome. */
+button, input, select, textarea { font-family: inherit; /* 1 */ font-size: 100%; /* 2 */ margin: 0; /* 3 */ }
+
+/** Address Firefox 4+ setting `line-height` on `input` using `!important` in the UA stylesheet. */
+button, input { line-height: normal; }
+
+/** Address inconsistent `text-transform` inheritance for `button` and `select`. All other form control elements do not inherit `text-transform` values. Correct `button` style inheritance in Chrome, Safari 5+, and IE 8+. Correct `select` style inheritance in Firefox 4+ and Opera. */
+button, select { text-transform: none; }
+
+/** 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio` and `video` controls. 2. Correct inability to style clickable `input` types in iOS. 3. Improve usability and consistency of cursor style between image-type `input` and others. */
+button, html input[type="button"], input[type="reset"], input[type="submit"] { -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ }
+
+/** Re-set default cursor for disabled elements. */
+button[disabled], html input[disabled] { cursor: default; }
+
+/** 1. Address box sizing set to `content-box` in IE 8/9. 2. Remove excess padding in IE 8/9. */
+input[type="checkbox"], input[type="radio"] { box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ }
+
+/** 1. Address `appearance` set to `searchfield` in Safari 5 and Chrome. 2. Address `box-sizing` set to `border-box` in Safari 5 and Chrome (include `-moz` to future-proof). */
+input[type="search"] { -webkit-appearance: textfield; /* 1 */ -moz-box-sizing: content-box; -webkit-box-sizing: content-box; /* 2 */ box-sizing: content-box; }
+
+/** Remove inner padding and search cancel button in Safari 5 and Chrome on OS X. */
+input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
+
+/** Remove inner padding and border in Firefox 4+. */
+button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
+
+/** 1. Remove default vertical scrollbar in IE 8/9. 2. Improve readability and alignment in all browsers. */
+textarea { overflow: auto; /* 1 */ vertical-align: top; /* 2 */ }
+
+/* ========================================================================== Tables ========================================================================== */
+/** Remove most spacing between table cells. */
+table { border-collapse: collapse; border-spacing: 0; }
+
+meta.foundation-mq-small { font-family: "only screen and (min-width: 768px)"; width: 768px; }
+
+meta.foundation-mq-medium { font-family: "only screen and (min-width:1280px)"; width: 1280px; }
+
+meta.foundation-mq-large { font-family: "only screen and (min-width:1440px)"; width: 1440px; }
+
+*, *:before, *:after { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; }
+
+html, body { font-size: 100%; }
+
+body { background: #fff; color: #222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
+
+a:hover { cursor: pointer; }
+
+img, object, embed { max-width: 100%; height: auto; }
+
+object, embed { height: 100%; }
+
+img { -ms-interpolation-mode: bicubic; }
+
+#map_canvas img, #map_canvas embed, #map_canvas object, .map_canvas img, .map_canvas embed, .map_canvas object { max-width: none !important; }
+
+.left { float: left !important; }
+
+.right { float: right !important; }
+
+.text-left { text-align: left !important; }
+
+.text-right { text-align: right !important; }
+
+.text-center { text-align: center !important; }
+
+.text-justify { text-align: justify !important; }
+
+.hide { display: none; }
+
+.antialiased, body { -webkit-font-smoothing: antialiased; }
+
+img { display: inline-block; vertical-align: middle; }
+
+textarea { height: auto; min-height: 50px; }
+
+select { width: 100%; }
+
+object, svg { display: inline-block; vertical-align: middle; }
+
+.center { margin-left: auto; margin-right: auto; }
+
+.spread { width: 100%; }
+
+p.lead, .paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { font-size: 1.21875em; line-height: 1.6; }
+
+.subheader, .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { line-height: 1.4; color: #003b6b; font-weight: 300; margin-top: 0.2em; margin-bottom: 0.5em; }
+
+/* Typography resets */
+div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; direction: ltr; }
+
+/* Default Link Styles */
+a { color: #00579e; text-decoration: none; line-height: inherit; }
+a:hover, a:focus { color: #333; }
+a img { border: none; }
+
+/* Default paragraph styles */
+p { font-family: Arial, sans-serif; font-weight: normal; font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; text-rendering: optimizeLegibility; }
+p aside { font-size: 0.875em; line-height: 1.35; font-style: italic; }
+
+/* Default header styles */
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { font-family: Arial, sans-serif; font-weight: normal; font-style: normal; color: #7B2D00; text-rendering: optimizeLegibility; margin-top: 0.5em; margin-bottom: 0.5em; line-height: 1.2125em; }
+h1 small, h2 small, h3 small, #toctitle small, .sidebarblock > .content > .title small, h4 small, h5 small, h6 small { font-size: 60%; color: #ff6b15; line-height: 0; }
+
+h1 { font-size: 2.125em; }
+
+h2 { font-size: 1.6875em; }
+
+h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.375em; }
+
+h4 { font-size: 1.125em; }
+
+h5 { font-size: 1.125em; }
+
+h6 { font-size: 1em; }
+
+hr { border: solid #ddd; border-width: 1px 0 0; clear: both; margin: 1.25em 0 1.1875em; height: 0; }
+
+/* Helpful Typography Defaults */
+em, i { font-style: italic; line-height: inherit; }
+
+strong, b { font-weight: bold; line-height: inherit; }
+
+small { font-size: 60%; line-height: inherit; }
+
+code { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: bold; color: #003426; }
+
+/* Lists */
+ul, ol, dl { font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; list-style-position: outside; font-family: Arial, sans-serif; }
+
+ul, ol { margin-left: 1.5em; }
+ul.no-bullet, ol.no-bullet { margin-left: 1.5em; }
+
+/* Unordered Lists */
+ul li ul, ul li ol { margin-left: 1.25em; margin-bottom: 0; font-size: 1em; /* Override nested font-size change */ }
+ul.square li ul, ul.circle li ul, ul.disc li ul { list-style: inherit; }
+ul.square { list-style-type: square; }
+ul.circle { list-style-type: circle; }
+ul.disc { list-style-type: disc; }
+ul.no-bullet { list-style: none; }
+
+/* Ordered Lists */
+ol li ul, ol li ol { margin-left: 1.25em; margin-bottom: 0; }
+
+/* Definition Lists */
+dl dt { margin-bottom: 0.3em; font-weight: bold; }
+dl dd { margin-bottom: 0.75em; }
+
+/* Abbreviations */
+abbr, acronym { text-transform: uppercase; font-size: 90%; color: black; border-bottom: 1px dotted #ddd; cursor: help; }
+
+abbr { text-transform: none; }
+
+/* Blockquotes */
+blockquote { margin: 0 0 0.75em; padding: 0.5625em 1.25em 0 1.1875em; border-left: 1px solid #ddd; }
+blockquote cite { display: block; font-size: 0.8125em; color: #e15200; }
+blockquote cite:before { content: "\2014 \0020"; }
+blockquote cite a, blockquote cite a:visited { color: #e15200; }
+
+blockquote, blockquote p { line-height: 1.6; color: #333; }
+
+/* Microformats */
+.vcard { display: inline-block; margin: 0 0 1.25em 0; border: 1px solid #ddd; padding: 0.625em 0.75em; }
+.vcard li { margin: 0; display: block; }
+.vcard .fn { font-weight: bold; font-size: 0.9375em; }
+
+.vevent .summary { font-weight: bold; }
+.vevent abbr { cursor: auto; text-decoration: none; font-weight: bold; border: none; padding: 0 0.0625em; }
+
+@media only screen and (min-width: 768px) { h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+  h1 { font-size: 2.75em; }
+  h2 { font-size: 2.3125em; }
+  h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.6875em; }
+  h4 { font-size: 1.4375em; } }
+/* Tables */
+table { background: #fff; margin-bottom: 1.25em; border: solid 1px #d8d8ce; }
+table thead, table tfoot { background: -webkit-linear-gradient(top, #add386, #90b66a); font-weight: bold; }
+table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: #fff; text-align: left; }
+table tr th, table tr td { padding: 0.5625em 0.625em; font-size: inherit; color: #6d6e71; }
+table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #edf2f2; }
+table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td { display: table-cell; line-height: 1.4; }
+
+body { tab-size: 4; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+
+a:hover, a:focus { text-decoration: underline; }
+
+.clearfix:before, .clearfix:after, .float-group:before, .float-group:after { content: " "; display: table; }
+.clearfix:after, .float-group:after { clear: both; }
+
+*:not(pre) > code { font-size: inherit; font-style: normal !important; letter-spacing: 0; padding: 3px 2px 1px 2px; background-color: #eee; border: 1px solid #ddd; -webkit-border-radius: 0; border-radius: 0; line-height: inherit; }
+
+pre, pre > code { line-height: 1.6; color: black; font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; }
+
+.keyseq { color: #333333; }
+
+kbd { font-family: Consolas, "Liberation Mono", Courier, monospace; display: inline-block; color: black; font-size: 0.65em; line-height: 1.45; background-color: #f7f7f7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -moz-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; margin: 0 0.15em; padding: 0.2em 0.5em; vertical-align: middle; position: relative; top: -0.1em; white-space: nowrap; }
+
+.keyseq kbd:first-child { margin-left: 0; }
+
+.keyseq kbd:last-child { margin-right: 0; }
+
+.menuseq, .menu { color: black; }
+
+b.button:before, b.button:after { position: relative; top: -1px; font-weight: normal; }
+
+b.button:before { content: "["; padding: 0 3px 0 2px; }
+
+b.button:after { content: "]"; padding: 0 2px 0 3px; }
+
+#header, #content, #footnotes, #footer { width: 100%; margin-left: auto; margin-right: auto; margin-top: 0; margin-bottom: 0; max-width: 62.5em; *zoom: 1; position: relative; padding-left: 1.5em; padding-right: 1.5em; }
+#header:before, #header:after, #content:before, #content:after, #footnotes:before, #footnotes:after, #footer:before, #footer:after { content: " "; display: table; }
+#header:after, #content:after, #footnotes:after, #footer:after { clear: both; }
+
+#content { margin-top: 1.25em; }
+
+#content:before { content: none; }
+
+#header > h1:first-child { color: #7B2D00; margin-top: 2.25rem; margin-bottom: 0; }
+#header > h1:first-child + #toc { margin-top: 8px; border-top: 1px solid #ddd; }
+#header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) { border-bottom: 1px solid #ddd; padding-bottom: 8px; }
+#header .details { border-bottom: 1px solid #ddd; line-height: 1.45; padding-top: 0.25em; padding-bottom: 0.25em; padding-left: 0.25em; color: #e15200; display: -ms-flexbox; display: -webkit-flex; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; }
+#header .details span:first-child { margin-left: -0.125em; }
+#header .details span.email a { color: #333; }
+#header .details br { display: none; }
+#header .details br + span:before { content: "\00a0\2013\00a0"; }
+#header .details br + span.author:before { content: "\00a0\22c5\00a0"; color: #333; }
+#header .details br + span#revremark:before { content: "\00a0|\00a0"; }
+#header #revnumber { text-transform: capitalize; }
+#header #revnumber:after { content: "\00a0"; }
+
+#content > h1:first-child:not([class]) { color: #7B2D00; border-bottom: 1px solid #ddd; padding-bottom: 8px; margin-top: 0; padding-top: 1rem; margin-bottom: 1.25rem; }
+
+#toc { border-bottom: 0 solid #ddd; padding-bottom: 0.5em; }
+#toc > ul { margin-left: 0.125em; }
+#toc ul.sectlevel0 > li > a { font-style: italic; }
+#toc ul.sectlevel0 ul.sectlevel1 { margin: 0.5em 0; }
+#toc ul { font-family: Arial, sans-serif; list-style-type: none; }
+#toc li { line-height: 1.3334; margin-top: 0.3334em; }
+#toc a { text-decoration: none; }
+#toc a:active { text-decoration: underline; }
+
+#toctitle { color: #003b6b; font-size: 1.2em; }
+
+@media only screen and (min-width: 768px) { #toctitle { font-size: 1.375em; }
+  body.toc2 { padding-left: 15em; padding-right: 0; }
+  #toc.toc2 { margin-top: 0 !important; background-color: #fff; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #ddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
+  #toc.toc2 #toctitle { margin-top: 0; margin-bottom: 0.8rem; font-size: 1.2em; }
+  #toc.toc2 > ul { font-size: 0.9em; margin-bottom: 0; }
+  #toc.toc2 ul ul { margin-left: 0; padding-left: 1em; }
+  #toc.toc2 ul.sectlevel0 ul.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 15em; }
+  body.toc2.toc-right #toc.toc2 { border-right-width: 0; border-left: 1px solid #ddd; left: auto; right: 0; } }
+@media only screen and (min-width: 1280px) { body.toc2 { padding-left: 20em; padding-right: 0; }
+  #toc.toc2 { width: 20em; }
+  #toc.toc2 #toctitle { font-size: 1.375em; }
+  #toc.toc2 > ul { font-size: 0.95em; }
+  #toc.toc2 ul ul { padding-left: 1.25em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 20em; } }
+#content #toc { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: #fff; -webkit-border-radius: 0; border-radius: 0; }
+#content #toc > :first-child { margin-top: 0; }
+#content #toc > :last-child { margin-bottom: 0; }
+
+#footer { max-width: 100%; background-color: none; padding: 1.25em; }
+
+#footer-text { color: black; line-height: 1.44; }
+
+.sect1 { padding-bottom: 0.625em; }
+
+@media only screen and (min-width: 768px) { .sect1 { padding-bottom: 1.25em; } }
+.sect1 + .sect1 { border-top: 0 solid #ddd; }
+
+#content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor { position: absolute; z-index: 1001; width: 1.5ex; margin-left: -1.5ex; display: block; text-decoration: none !important; visibility: hidden; text-align: center; font-weight: normal; }
+#content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > .content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before { content: "\00A7"; font-size: 0.85em; display: block; padding-top: 0.1em; }
+#content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > .content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > .content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover { visibility: visible; }
+#content h1 > a.link, h2 > a.link, h3 > a.link, #toctitle > a.link, .sidebarblock > .content > .title > a.link, h4 > a.link, h5 > a.link, h6 > a.link { color: #7B2D00; text-decoration: none; }
+#content h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, #toctitle > a.link:hover, .sidebarblock > .content > .title > a.link:hover, h4 > a.link:hover, h5 > a.link:hover, h6 > a.link:hover { color: #622400; }
+
+.audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .videoblock { margin-bottom: 1.25em; }
+
+.admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { text-rendering: optimizeLegibility; text-align: left; }
+
+table.tableblock > caption.title { white-space: nowrap; overflow: visible; max-width: 0; }
+
+.paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { color: #7B2D00; }
+
+table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-size: inherit; }
+
+.admonitionblock > table { border-collapse: separate; border: 0; background: none; width: 100%; }
+.admonitionblock > table td.icon { text-align: center; width: 80px; }
+.admonitionblock > table td.icon img { max-width: none; }
+.admonitionblock > table td.icon .title { font-weight: bold; font-family: Arial, sans-serif; text-transform: uppercase; }
+.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #ddd; color: #e15200; }
+.admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
+
+.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: #fff; -webkit-border-radius: 0; border-radius: 0; }
+.exampleblock > .content > :first-child { margin-top: 0; }
+.exampleblock > .content > :last-child { margin-bottom: 0; }
+
+.sidebarblock { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: #fff; -webkit-border-radius: 0; border-radius: 0; }
+.sidebarblock > :first-child { margin-top: 0; }
+.sidebarblock > :last-child { margin-bottom: 0; }
+.sidebarblock > .content > .title { color: #003b6b; margin-top: 0; }
+
+.exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
+
+.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #eee; }
+.sidebarblock .literalblock pre, .sidebarblock .listingblock pre:not(.highlight), .sidebarblock .listingblock pre[class="highlight"], .sidebarblock .listingblock pre[class^="highlight "], .sidebarblock .listingblock pre.CodeRay, .sidebarblock .listingblock pre.prettyprint { background: #f2f1f1; }
+
+.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 1px dashed #666; -webkit-border-radius: 0; border-radius: 0; word-wrap: break-word; padding: 1.25em 1.5625em 1.125em 1.5625em; font-size: 0.8125em; }
+.literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap { overflow-x: auto; white-space: pre; word-wrap: normal; }
+@media only screen and (min-width: 768px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 0.90625em; } }
+@media only screen and (min-width: 1280px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 1em; } }
+
+.literalblock.output pre { color: #eee; background-color: black; }
+
+.listingblock pre.highlightjs { padding: 0; }
+.listingblock pre.highlightjs > code { padding: 1.25em 1.5625em 1.125em 1.5625em; -webkit-border-radius: 0; border-radius: 0; }
+
+.listingblock > .content { position: relative; }
+
+.listingblock code[data-lang]:before { display: none; content: attr(data-lang); position: absolute; font-size: 0.75em; top: 0.425rem; right: 0.5rem; line-height: 1; text-transform: uppercase; color: #999; }
+
+.listingblock:hover code[data-lang]:before { display: block; }
+
+.listingblock.terminal pre .command:before { content: attr(data-prompt); padding-right: 0.5em; color: #999; }
+
+.listingblock.terminal pre .command:not([data-prompt]):before { content: "$"; }
+
+table.pyhltable { border-collapse: separate; border: 0; margin-bottom: 0; background: none; }
+
+table.pyhltable td { vertical-align: top; padding-top: 0; padding-bottom: 0; line-height: 1.6; }
+
+table.pyhltable td.code { padding-left: .75em; padding-right: 0; }
+
+pre.pygments .lineno, table.pyhltable td:not(.code) { color: #999; padding-left: 0; padding-right: .5em; border-right: 1px solid #ddd; }
+
+pre.pygments .lineno { display: inline-block; margin-right: .25em; }
+
+table.pyhltable .linenodiv { background: none !important; padding-right: 0 !important; }
+
+.quoteblock { margin: 0 1em 0.75em 1.5em; display: table; }
+.quoteblock > .title { margin-left: -1.5em; margin-bottom: 0.75em; }
+.quoteblock blockquote, .quoteblock blockquote p { color: #333; font-size: 1.15rem; line-height: 1.75; word-spacing: 0.1em; letter-spacing: 0; font-style: italic; text-align: justify; }
+.quoteblock blockquote { margin: 0; padding: 0; border: 0; }
+.quoteblock blockquote:before { content: "\201c"; float: left; font-size: 2.75em; font-weight: bold; line-height: 0.6em; margin-left: -0.6em; color: #003b6b; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
+.quoteblock blockquote > .paragraph:last-child p { margin-bottom: 0; }
+.quoteblock .attribution { margin-top: 0.5em; margin-right: 0.5ex; text-align: right; }
+.quoteblock .quoteblock { margin-left: 0; margin-right: 0; padding: 0.5em 0; border-left: 3px solid #e15200; }
+.quoteblock .quoteblock blockquote { padding: 0 0 0 0.75em; }
+.quoteblock .quoteblock blockquote:before { display: none; }
+
+.verseblock { margin: 0 1em 0.75em 1em; }
+.verseblock pre { font-family: "Open Sans", "DejaVu Sans", sans; font-size: 1.15rem; color: #333; font-weight: 300; text-rendering: optimizeLegibility; }
+.verseblock pre strong { font-weight: 400; }
+.verseblock .attribution { margin-top: 1.25rem; margin-left: 0.5ex; }
+
+.quoteblock .attribution, .verseblock .attribution { font-size: 0.8125em; line-height: 1.45; font-style: italic; }
+.quoteblock .attribution br, .verseblock .attribution br { display: none; }
+.quoteblock .attribution cite, .verseblock .attribution cite { display: block; letter-spacing: -0.025em; color: #e15200; }
+
+.quoteblock.abstract { margin: 0 0 0.75em 0; display: block; }
+.quoteblock.abstract blockquote, .quoteblock.abstract blockquote p { text-align: left; word-spacing: 0; }
+.quoteblock.abstract blockquote:before, .quoteblock.abstract blockquote p:first-of-type:before { display: none; }
+
+table.tableblock { max-width: 100%; border-collapse: separate; }
+table.tableblock td > .paragraph:last-child p > p:last-child, table.tableblock th > p:last-child, table.tableblock td > p:last-child { margin-bottom: 0; }
+
+table.tableblock, th.tableblock, td.tableblock { border: 0 solid #d8d8ce; }
+
+table.grid-all th.tableblock, table.grid-all td.tableblock { border-width: 0 1px 1px 0; }
+
+table.grid-all tfoot > tr > th.tableblock, table.grid-all tfoot > tr > td.tableblock { border-width: 1px 1px 0 0; }
+
+table.grid-cols th.tableblock, table.grid-cols td.tableblock { border-width: 0 1px 0 0; }
+
+table.grid-all * > tr > .tableblock:last-child, table.grid-cols * > tr > .tableblock:last-child { border-right-width: 0; }
+
+table.grid-rows th.tableblock, table.grid-rows td.tableblock { border-width: 0 0 1px 0; }
+
+table.grid-all tbody > tr:last-child > th.tableblock, table.grid-all tbody > tr:last-child > td.tableblock, table.grid-all thead:last-child > tr > th.tableblock, table.grid-rows tbody > tr:last-child > th.tableblock, table.grid-rows tbody > tr:last-child > td.tableblock, table.grid-rows thead:last-child > tr > th.tableblock { border-bottom-width: 0; }
+
+table.grid-rows tfoot > tr > th.tableblock, table.grid-rows tfoot > tr > td.tableblock { border-width: 1px 0 0 0; }
+
+table.frame-all { border-width: 1px; }
+
+table.frame-sides { border-width: 0 1px; }
+
+table.frame-topbot { border-width: 1px 0; }
+
+th.halign-left, td.halign-left { text-align: left; }
+
+th.halign-right, td.halign-right { text-align: right; }
+
+th.halign-center, td.halign-center { text-align: center; }
+
+th.valign-top, td.valign-top { vertical-align: top; }
+
+th.valign-bottom, td.valign-bottom { vertical-align: bottom; }
+
+th.valign-middle, td.valign-middle { vertical-align: middle; }
+
+table thead th, table tfoot th { font-weight: bold; }
+
+tbody tr th { display: table-cell; line-height: 1.4; background: -webkit-linear-gradient(top, #add386, #90b66a); }
+
+tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p { color: #fff; font-weight: bold; }
+
+p.tableblock > code:only-child { background: none; padding: 0; }
+
+p.tableblock { font-size: 1em; }
+
+td > div.verse { white-space: pre; }
+
+ol { margin-left: 1.75em; }
+
+ul li ol { margin-left: 1.5em; }
+
+dl dd { margin-left: 1.125em; }
+
+dl dd:last-child, dl dd:last-child > :last-child { margin-bottom: 0; }
+
+ol > li p, ul > li p, ul dd, ol dd, .olist .olist, .ulist .ulist, .ulist .olist, .olist .ulist { margin-bottom: 0.375em; }
+
+ul.unstyled, ol.unnumbered, ul.checklist, ul.none { list-style-type: none; }
+
+ul.unstyled, ol.unnumbered, ul.checklist { margin-left: 0.625em; }
+
+ul.checklist li > p:first-child > .fa-square-o:first-child, ul.checklist li > p:first-child > .fa-check-square-o:first-child { width: 1em; font-size: 0.85em; }
+
+ul.checklist li > p:first-child > input[type="checkbox"]:first-child { width: 1em; position: relative; top: 1px; }
+
+ul.inline { margin: 0 auto 0.375em auto; margin-left: -1.375em; margin-right: 0; padding: 0; list-style: none; overflow: hidden; }
+ul.inline > li { list-style: none; float: left; margin-left: 1.375em; display: block; }
+ul.inline > li > * { display: block; }
+
+.unstyled dl dt { font-weight: normal; font-style: normal; }
+
+ol.arabic { list-style-type: decimal; }
+
+ol.decimal { list-style-type: decimal-leading-zero; }
+
+ol.loweralpha { list-style-type: lower-alpha; }
+
+ol.upperalpha { list-style-type: upper-alpha; }
+
+ol.lowerroman { list-style-type: lower-roman; }
+
+ol.upperroman { list-style-type: upper-roman; }
+
+ol.lowergreek { list-style-type: lower-greek; }
+
+.hdlist > table, .colist > table { border: 0; background: none; }
+.hdlist > table > tbody > tr, .colist > table > tbody > tr { background: none; }
+
+td.hdlist1, td.hdlist2 { vertical-align: top; padding: 0 0.625em; }
+
+td.hdlist1 { font-weight: bold; padding-bottom: 0.75em; }
+
+.literalblock + .colist, .listingblock + .colist { margin-top: -0.5em; }
+
+.colist > table tr > td:first-of-type { padding: 0 0.75em; line-height: 1; }
+.colist > table tr > td:last-of-type { padding: 0.25em 0; }
+
+.thumb, .th { line-height: 0; display: inline-block; border: solid 4px #fff; -webkit-box-shadow: 0 0 0 1px #ddd; box-shadow: 0 0 0 1px #ddd; }
+
+.imageblock.left, .imageblock[style*="float: left"] { margin: 0.25em 0.625em 1.25em 0; }
+.imageblock.right, .imageblock[style*="float: right"] { margin: 0.25em 0 1.25em 0.625em; }
+.imageblock > .title { margin-bottom: 0; }
+.imageblock.thumb, .imageblock.th { border-width: 6px; }
+.imageblock.thumb > .title, .imageblock.th > .title { padding: 0 0.125em; }
+
+.image.left, .image.right { margin-top: 0.25em; margin-bottom: 0.25em; display: inline-block; line-height: 0; }
+.image.left { margin-right: 0.625em; }
+.image.right { margin-left: 0.625em; }
+
+a.image { text-decoration: none; display: inline-block; }
+a.image object { pointer-events: none; }
+
+sup.footnote, sup.footnoteref { font-size: 0.875em; position: static; vertical-align: super; }
+sup.footnote a, sup.footnoteref a { text-decoration: none; }
+sup.footnote a:active, sup.footnoteref a:active { text-decoration: underline; }
+
+#footnotes { padding-top: 0.75em; padding-bottom: 0.75em; margin-bottom: 0.625em; }
+#footnotes hr { width: 20%; min-width: 6.25em; margin: -0.25em 0 0.75em 0; border-width: 1px 0 0 0; }
+#footnotes .footnote { padding: 0 0.375em 0 0.225em; line-height: 1.3334; font-size: 0.875em; margin-left: 1.2em; text-indent: -1.05em; margin-bottom: 0.2em; }
+#footnotes .footnote a:first-of-type { font-weight: bold; text-decoration: none; }
+#footnotes .footnote:last-of-type { margin-bottom: 0; }
+#content #footnotes { margin-top: -0.625em; margin-bottom: 0; padding: 0.75em 0; }
+
+.gist .file-data > table { border: 0; background: #fff; width: 100%; margin-bottom: 0; }
+.gist .file-data > table td.line-data { width: 99%; }
+
+div.unbreakable { page-break-inside: avoid; }
+
+.big { font-size: larger; }
+
+.small { font-size: smaller; }
+
+.underline { text-decoration: underline; }
+
+.overline { text-decoration: overline; }
+
+.line-through { text-decoration: line-through; }
+
+.aqua { color: #00bfbf; }
+
+.aqua-background { background-color: #00fafa; }
+
+.black { color: black; }
+
+.black-background { background-color: black; }
+
+.blue { color: #0000bf; }
+
+.blue-background { background-color: #0000fa; }
+
+.fuchsia { color: #bf00bf; }
+
+.fuchsia-background { background-color: #fa00fa; }
+
+.gray { color: #606060; }
+
+.gray-background { background-color: #7d7d7d; }
+
+.green { color: #006000; }
+
+.green-background { background-color: #007d00; }
+
+.lime { color: #00bf00; }
+
+.lime-background { background-color: #00fa00; }
+
+.maroon { color: #600000; }
+
+.maroon-background { background-color: #7d0000; }
+
+.navy { color: #000060; }
+
+.navy-background { background-color: #00007d; }
+
+.olive { color: #606000; }
+
+.olive-background { background-color: #7d7d00; }
+
+.purple { color: #600060; }
+
+.purple-background { background-color: #7d007d; }
+
+.red { color: #bf0000; }
+
+.red-background { background-color: #fa0000; }
+
+.silver { color: #909090; }
+
+.silver-background { background-color: #bcbcbc; }
+
+.teal { color: #006060; }
+
+.teal-background { background-color: #007d7d; }
+
+.white { color: #bfbfbf; }
+
+.white-background { background-color: #fafafa; }
+
+.yellow { color: #bfbf00; }
+
+.yellow-background { background-color: #fafa00; }
+
+span.icon > .fa { cursor: default; }
+
+.admonitionblock td.icon [class^="fa icon-"] { font-size: 2.5em; text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5); cursor: default; }
+.admonitionblock td.icon .icon-note:before { content: "\f05a"; color: #004177; }
+.admonitionblock td.icon .icon-tip:before { content: "\f0eb"; text-shadow: 1px 1px 2px rgba(155, 155, 0, 0.8); color: #111; }
+.admonitionblock td.icon .icon-warning:before { content: "\f071"; color: #bf6900; }
+.admonitionblock td.icon .icon-caution:before { content: "\f06d"; color: #bf3400; }
+.admonitionblock td.icon .icon-important:before { content: "\f06a"; color: #bf0000; }
+
+.conum[data-value] { display: inline-block; color: #fff !important; background-color: black; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; font-size: 0.75em; width: 1.67em; height: 1.67em; line-height: 1.67em; font-family: "Open Sans", "DejaVu Sans", sans-serif; font-style: normal; font-weight: bold; }
+.conum[data-value] * { color: #fff !important; }
+.conum[data-value] + b { display: none; }
+.conum[data-value]:after { content: attr(data-value); }
+pre .conum[data-value] { position: relative; top: -0.125em; }
+
+b.conum * { color: inherit !important; }
+
+.conum:not([data-value]):empty { display: none; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { border-bottom: 1px solid #ddd; }
+
+.sect1 { padding-bottom: 0; }
+
+#toctitle { color: #00406F; font-weight: normal; margin-top: 1.5em; }
+
+.sidebarblock { border-color: #aaa; }
+
+code { -webkit-border-radius: 4px; border-radius: 4px; }
+
+p.tableblock.header { color: #6d6e71; }
+
+.literalblock pre, .listingblock pre { background: #eee; }

--- a/doc/tcpmuxd.txt
+++ b/doc/tcpmuxd.txt
@@ -20,7 +20,7 @@ THE FUNCTIONALITY IS SUBJECT TO CHANGE WITHOUT PRIOR NOTICE.
 TCP multiplexer daemon listens on all network interfaces on TCP port specified
 by argument PORT. On each incoming connection it performs TCPMUX handshake as
 defined in RFC 1078. Then it hands the connection to the application bound to
-the service name specified by the client (see linknanomsg:tcpmux[7] for more
+the service name specified by the client (see <<tcpmux.7.txt#,tcpmux(7)>> for more
 details).
 
 
@@ -31,11 +31,11 @@ There are no options defined.
 
 SEE ALSO
 --------
-linknanomsg:tcpmux[7]
-linknanomsg:nanomsg[7]
+<<tcpmux.7.txt#,tcpmux(7)>>
+<<nanomsg.7.txt#,nanomsg(7)>>
 
 AUTHORS
 -------
 
-Martin Sustrik <sustrik@250bpm.com>
+link:mailto:sustrik@250bpm.com[Martin Sustrik]
 


### PR DESCRIPTION
Test... formatted pages can be found at 

http://nanomsg.org/asciidoctor/colony/nanomsg.7.html

Other themes for testing:

asciidoctor:  http://nanomsg.org/asciidoctor/default/nanomsg.7.html
github:  http://nanomsg.org/asciidoctor/github/nanomsg.7.html
golo:  http://nanomsg.org/asciidoctor/golo/nanomsg.7.html
maker: http://nanomsg.org/asciidoctor/maker/nanomsg.7.html
readthedocs: http://nanomsg.org/asciidoctor/readthedocs/nanomsg.7.html
riak:  http://nanomsg.org/asciidoctor/riak/nanomsg.7.html
rubygems: http://nanomsg.org/asciidoctor/rubygems/nanomsg.7.html

The theme is super easy to swap out.  This PR uses colony as the default, but happy to change if there is a strong desire for something else (one of the above, or if someone is a CSS expert and wants to put a better one together...)