### PR TITLE
fixes #574 Migrate to CMake for all environments

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,22 @@
+version: 0.8.{build}
+environment:
+  matrix:
+    # array of all environments used to test builds
+    - GENERATOR: Visual Studio 14 2015
+      CFG: Debug
+    - GENERATOR: Visual Studio 12 2013
+      CFG: Debug
+    - GENERATOR: Visual Studio 14 2015 Win64
+      CFG: Debug
+    - GENERATOR: Visual Studio 12 2013 Win64
+      CFG: Debug
+build:
+  parallel: true
+build_script:
+  - cmd: cmake --version
+  - cmd: md build
+  - cmd: cd build
+  - cmd: cmake -G "%GENERATOR%" ..
+  - cmd: cmake --build .
+test_script:
+  - cmd: ctest --output-on-failure -C "%CFG%"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,28 @@
 language: c
 sudo: false
-compiler:
-- clang
-- gcc
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+    - os: linux
+      compiler: clang
+#    - os: osx
+#      compiler: gcc
+    - os: osx
+      compiler: clang
 script:
-- ./autogen.sh
-- ./configure
-- make distcheck
+  # Print all environment variables to aid in CI development
+  - printenv
+  # Print version and available CMake generators to aid in CI development
+  - cmake --version
+  - cmake --help
+  # Perform out-of-source build
+  - mkdir build
+  - cd build
+  # Perform CMake backend generation, build, and test
+  - cmake ..
+  - cmake --build .
+  - ctest --output-on-failure -C Debug
 deploy:
   provider: releases
   api_key:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 #
 #   Copyright (c) 2012 Martin Sustrik  All rights reserved.
 #   Copyright (c) 2013 GoPivotal, Inc.  All rights reserved.
+#   Copyright (c) 2015-2016 Jack R. Dunaway. All rights reserved.
 #   Copyright 2016 Garrett D'Amore <garrett@damore.org>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,35 +23,195 @@
 #   IN THE SOFTWARE.
 #
 
-cmake_minimum_required (VERSION 2.8)
-include (CheckIncludeFiles)
+cmake_minimum_required (VERSION 2.8.7)
+include (CheckFunctionExists)
 include (CheckSymbolExists)
+include (CheckLibraryExists)
 include (CheckCSourceCompiles)
 
 project (nanomsg C)
 enable_testing ()
 
-#  Platform checks.
+set (ISSUE_REPORT_MSG "Please consider opening an issue at https://github.com/nanomsg/nanomsg with your findings")
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    add_definitions (-DNN_HAVE_WINDOWS)
-    add_definitions (-D_CRT_SECURE_NO_WARNINGS)
+# Determine library versions.
 
-    if (MINGW)
-        add_definitions (-DNN_HAVE_MINGW -DNN_HAVE_STDINT -D_WIN32_WINNT=0x0600)
-    endif ()
+file (READ src/nn.h NN_HDR_STR)
+string (REGEX REPLACE ".*#define +NN_VERSION_CURRENT +([0-9]+).*" "\\1" NN_VERSION_CURRENT "${NN_HDR_STR}")
+string (REGEX REPLACE ".*#define +NN_VERSION_REVISION +([0-9]+).*" "\\1" NN_VERSION_REVISION "${NN_HDR_STR}")
+string (REGEX REPLACE ".*#define +NN_VERSION_AGE +([0-9]+).*" "\\1" NN_VERSION_AGE "${NN_HDR_STR}")
+
+if ((NN_VERSION_CURRENT STREQUAL "") OR (NN_VERSION_REVISION STREQUAL "") OR (NN_VERSION_AGE STREQUAL ""))
+    message (FATAL_ERROR "Could not read ABI version from nn.h")
 else ()
-    message (FATAL_ERROR "ERROR: CMake build system is intended only to generate MSVC solution files.\nUse autotools build system for any other purpose." )
+    set (NN_ABI_VERSION "${NN_VERSION_CURRENT}.${NN_VERSION_REVISION}.${NN_VERSION_AGE}")
+    message (STATUS "Detected nanomsg ABI v${NN_ABI_VERSION}")
 endif ()
 
-#  Build the library itself.
+# Determine package version.
+find_package (Git QUIET)
+if (DEFINED ENV{TRAVIS_TAG})
+    set (NN_PACKAGE_VERSION "$ENV{TRAVIS_TAG}")
+elseif (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+    # Working off a git repo, using git versioning
+
+    # Get version from last tag
+    execute_process (
+        COMMAND             "${GIT_EXECUTABLE}" describe --always# | sed -e "s:v::"
+        WORKING_DIRECTORY   "${PROJECT_SOURCE_DIR}"
+        OUTPUT_VARIABLE     NN_PACKAGE_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    # If the sources have been changed locally, add -dirty to the version.
+    execute_process (
+        COMMAND             "${GIT_EXECUTABLE}" diff --quiet
+        WORKING_DIRECTORY   "${PROJECT_SOURCE_DIR}"
+        RESULT_VARIABLE     res)
+    if (res EQUAL 1)
+        set (NN_PACKAGE_VERSION "${NN_PACKAGE_VERSION}-dirty")
+    endif()
+
+elseif (EXISTS .version)
+    #  If git is not available (e.g. when building from source package)
+    #  we can extract the package version from .version file.
+    file (READ .version NN_PACKAGE_VERSION)
+else ()
+    set (NN_PACKAGE_VERSION "Unknown")
+endif()
+
+# User-defined options.
+
+option (ENABLE_NANOCAT "Enable building nanocat utility." OFF)
+option (NN_STATIC_LIB "Build static library instead of shared library." OFF)
+option (ENABLE_GETADDRINFO_A "Enable/disable use of getaddrinfo_a in place of getaddrinfo." ON)
+
+#  Platform checks.
+
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    add_definitions (-DNN_HAVE_LINUX)
+    find_package (Threads REQUIRED)
+elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    add_definitions (-DNN_HAVE_OSX)
+    find_package (Threads REQUIRED)
+elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+    SET (NN_HAVE_WINSOCK 1)
+    add_definitions (-DNN_HAVE_WINDOWS)
+    add_definitions (-D_CRT_SECURE_NO_WARNINGS)
+elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+    add_definitions (-DNN_HAVE_FREEBSD)
+    find_package (Threads REQUIRED)
+elseif (CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+    add_definitions (-DNN_HAVE_NETBSD)
+    find_package (Threads REQUIRED)
+elseif (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+    add_definitions (-DNN_HAVE_OPENBSD)
+    find_package (Threads REQUIRED)
+elseif (CMAKE_SYSTEM_NAME MATCHES "Solaris|SunOS")
+    add_definitions (-DNN_HAVE_SOLARIS)
+    find_package (Threads REQUIRED)
+    check_library_exists (socket socket "" NN_HAVE_SOLARIS_SOCKET)
+    check_library_exists (nsl gethostbyname "" NN_HAVE_SOLARIS_GETHOSTBYNAME)
+elseif (CMAKE_SYSTEM_NAME MATCHES "QNX")
+    add_definitions (-DNN_HAVE_QNX)
+    find_package (Threads REQUIRED)
+    check_library_exists (socket socket "" NN_HAVE_QNX_SOCKET)
+else ()
+    message (AUTHOR_WARNING "WARNING: This platform may or may not be supported: ${CMAKE_SYSTEM_NAME}")
+    message (AUTHOR_WARNING "${ISSUE_REPORT_MSG}")
+endif ()
+
+check_function_exists (gethrtime NN_HAVE_GETHRTIME)
+check_function_exists (socketpair NN_HAVE_SOCKETPAIR)
+check_function_exists (eventfd NN_HAVE_EVENTFD)
+check_function_exists (pipe NN_HAVE_PIPE)
+check_function_exists (pipe2 NN_HAVE_PIPE2)
+check_function_exists (accept4 NN_HAVE_ACCEPT4)
+check_function_exists (epoll_create NN_HAVE_EPOLL)
+check_function_exists (kqueue NN_HAVE_KQUEUE)
+check_function_exists (poll NN_HAVE_POLL)
+
+check_library_exists (anl getaddrinfo_a "" NN_HAVE_GETADDRINFO_A)
+check_library_exists (rt clock_gettime "" NN_HAVE_CLOCK_GETTIME)
+check_library_exists (rt sem_wait "" NN_HAVE_SEMAPHORE_RT)
+check_library_exists (pthread sem_wait  "" NN_HAVE_SEMAPHORE_PTHREAD)
+
+if (NN_HAVE_POLL)
+    add_definitions (-DNN_HAVE_POLL)
+endif ()
+
+if (NN_HAVE_SEMAPHORE_RT OR NN_HAVE_SEMAPHORE_PTHREAD)
+    add_definitions (-DNN_HAVE_SEMAPHORE)
+endif ()
+
+if (NOT ENABLE_GETADDRINFO_A)
+    add_definitions (-DNN_DISABLE_GETADDRINFO_A)
+endif ()
+
+if (NN_HAVE_PIPE2 OR NN_HAVE_ACCEPT4 OR NN_HAVE_GETADDRINFO_A)
+    add_definitions (-D_GNU_SOURCE)
+endif ()
+
+check_c_source_compiles ("
+    #include <time.h>
+    int main()
+    {
+        struct timespec ts;
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        return 0;
+    }
+" NN_HAVE_CLOCK_MONOTONIC)
+if (NN_HAVE_CLOCK_MONOTONIC)
+    add_definitions (-DNN_HAVE_CLOCK_MONOTONIC)
+endif ()
+
+check_c_source_compiles ("
+    #include <stdint.h>
+    int main()
+    {
+        volatile uint32_t n = 0;
+        __sync_fetch_and_add (&n, 1);
+        __sync_fetch_and_sub (&n, 1);
+        return 0;
+    }
+" NN_HAVE_GCC_ATOMIC_BUILTINS)
+if (NN_HAVE_GCC_ATOMIC_BUILTINS)
+    add_definitions (-DNN_HAVE_GCC_ATOMIC_BUILTINS)
+endif ()
+
+check_c_source_compiles ("
+    #include <atomic.h>
+    int main()
+    {
+        uint32_t value;
+        atomic_cas_32 (&value, 0, 0);
+        return 0;
+    }
+" NN_HAVE_ATOMIC_SOLARIS)
+if (NN_HAVE_ATOMIC_SOLARIS)
+    add_definitions (-DNN_HAVE_ATOMIC_SOLARIS)
+endif ()
+
+check_c_source_compiles ("
+    #include <sys/socket.h>
+    int main()
+    {
+        struct msghdr hdr;
+        hdr.msg_control = 0;
+        return 0;
+    }
+" NN_HAVE_MSG_CONTROL)
+if (NN_HAVE_MSG_CONTROL)
+    add_definitions (-DNN_HAVE_MSG_CONTROL)
+endif ()
 
 add_subdirectory (src)
 
 #  Build the tools
 
-add_executable (nanocat tools/nanocat.c tools/options.c)
-target_link_libraries (nanocat nanomsg)
+if (ENABLE_NANOCAT)
+    add_executable (nanocat tools/nanocat.c tools/options.c)
+    target_link_libraries (nanocat ${PROJECT_NAME})
+endif ()
 
 #  Build unit tests.
 
@@ -59,7 +220,7 @@ set (all_tests "")
 macro (add_libnanomsg_test NAME TIMEOUT)
     list (APPEND all_tests ${NAME})
     add_executable (${NAME} tests/${NAME}.c)
-    target_link_libraries (${NAME} nanomsg)
+    target_link_libraries (${NAME} ${PROJECT_NAME})
     add_test (NAME ${NAME} COMMAND ${NAME})
     set_tests_properties (${NAME} PROPERTIES TIMEOUT ${TIMEOUT})
 endmacro (add_libnanomsg_test)
@@ -71,7 +232,7 @@ add_libnanomsg_test (ipc 5)
 add_libnanomsg_test (ipc_shutdown 30)
 add_libnanomsg_test (ipc_stress 5)
 add_libnanomsg_test (tcp 5)
-add_libnanomsg_test (tcp_shutdown 120)
+add_libnanomsg_test (tcp_shutdown 30)
 add_libnanomsg_test (ws 5)
 
 #  Protocol tests.
@@ -83,7 +244,7 @@ add_libnanomsg_test (survey 5)
 add_libnanomsg_test (bus 5)
 
 #  Feature tests.
-add_libnanomsg_test (async_shutdown 5)
+add_libnanomsg_test (async_shutdown 30)
 add_libnanomsg_test (block 5)
 add_libnanomsg_test (term 5)
 add_libnanomsg_test (timeo 5)
@@ -95,7 +256,7 @@ add_libnanomsg_test (device 5)
 add_libnanomsg_test (device4 5)
 add_libnanomsg_test (device5 5)
 add_libnanomsg_test (device6 5)
-add_libnanomsg_test (device7 120)
+add_libnanomsg_test (device7 30)
 add_libnanomsg_test (emfile 5)
 add_libnanomsg_test (domain 5)
 add_libnanomsg_test (trie 5)
@@ -108,13 +269,17 @@ add_libnanomsg_test (zerocopy 5)
 add_libnanomsg_test (shutdown 5)
 add_libnanomsg_test (cmsg 5)
 add_libnanomsg_test (bug328 5)
-add_libnanomsg_test (win_sec_attr 5)
+
+# Platform-specific tests
+if (WIN32)
+    add_libnanomsg_test (win_sec_attr 5)
+endif()
 
 #  Build the performance tests.
 
 macro (add_libnanomsg_perf NAME)
     add_executable (${NAME} perf/${NAME}.c)
-    target_link_libraries (${NAME} nanomsg)
+    target_link_libraries (${NAME} ${PROJECT_NAME})
 endmacro (add_libnanomsg_perf)
 
 add_libnanomsg_perf (inproc_lat)
@@ -138,8 +303,10 @@ install (FILES src/pipeline.h DESTINATION include/nanomsg)
 install (FILES src/survey.h DESTINATION include/nanomsg)
 install (FILES src/bus.h DESTINATION include/nanomsg)
 
-install (TARGETS nanocat RUNTIME DESTINATION bin)
+if (BUILD_NANOCAT)
+    install (TARGETS nanocat RUNTIME DESTINATION bin)
+endif()
 
 set (CPACK_GENERATOR "NSIS")
-set (CPACK_PACKAGE_NAME "nanomsg")
+set (CPACK_PACKAGE_NAME ${PROJECT_NAME})
 include (CPack)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 #
 #   Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
 #   Copyright (c) 2013 GoPivotal, Inc.  All rights reserved.
+#   Copyright (c) 2015-2016 Jack R. Dunaway. All rights reserved.
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
 #   of this software and associated documentation files (the "Software"),
@@ -20,10 +21,6 @@
 #   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 #   IN THE SOFTWARE.
 #
-
-set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 set (NN_SOURCES
     nn.h
@@ -54,14 +51,6 @@ set (NN_SOURCES
     aio/ctx.c
     aio/fsm.h
     aio/fsm.c
-    aio/poller.h
-    aio/poller.c
-    aio/poller_epoll.h
-    aio/poller_epoll.inc
-    aio/poller_kqueue.h
-    aio/poller_kqueue.inc
-    aio/poller_poll.h
-    aio/poller_poll.inc
     aio/pool.h
     aio/pool.c
     aio/timer.h
@@ -70,16 +59,8 @@ set (NN_SOURCES
     aio/timerset.c
     aio/usock.h
     aio/usock.c
-    aio/usock_posix.h
-    aio/usock_posix.inc
-    aio/usock_win.h
-    aio/usock_win.inc
     aio/worker.h
     aio/worker.c
-    aio/worker_posix.h
-    aio/worker_posix.inc
-    aio/worker_win.h
-    aio/worker_win.inc
 
     utils/alloc.h
     utils/alloc.c
@@ -97,14 +78,6 @@ set (NN_SOURCES
     utils/cont.h
     utils/efd.h
     utils/efd.c
-    utils/efd_eventfd.h
-    utils/efd_eventfd.inc
-    utils/efd_pipe.h
-    utils/efd_pipe.inc
-    utils/efd_socketpair.h
-    utils/efd_socketpair.inc
-    utils/efd_win.h
-    utils/efd_win.inc
     utils/err.h
     utils/err.c
     utils/fast.h
@@ -129,10 +102,6 @@ set (NN_SOURCES
     utils/sleep.c
     utils/thread.h
     utils/thread.c
-    utils/thread_posix.h
-    utils/thread_posix.inc
-    utils/thread_win.h
-    utils/thread_win.inc
     utils/wire.h
     utils/wire.c
 
@@ -271,20 +240,133 @@ set (NN_SOURCES
 )
 
 if (WIN32)
-    LIST (APPEND NN_SOURCES
+    list (APPEND NN_SOURCES
+        aio/usock_win.h
+        aio/usock_win.inc
+        aio/worker_win.h
+        aio/worker_win.inc
+        utils/thread_win.h
+        utils/thread_win.inc
         utils/win.h
     )
+elseif (UNIX)
+    list (APPEND NN_SOURCES
+        aio/usock_posix.h
+        aio/usock_posix.inc
+        aio/worker_posix.h
+        aio/worker_posix.inc
+        utils/thread_posix.h
+        utils/thread_posix.inc
+    )
+else ()
+    message (FATAL_ERROR "Assertion failed; this path is unreachable.")
 endif ()
 
-add_library (nanomsg SHARED ${NN_SOURCES})
+if (NN_HAVE_EPOLL)
+    add_definitions (-DNN_USE_EPOLL)
+    list (APPEND NN_SOURCES
+        aio/poller.h
+        aio/poller.c
+        aio/poller_epoll.h
+        aio/poller_epoll.inc
+    )
+elseif (NN_HAVE_KQUEUE)
+    add_definitions (-DNN_USE_KQUEUE)
+    list (APPEND NN_SOURCES
+        aio/poller.h
+        aio/poller.c
+        aio/poller_kqueue.h
+        aio/poller_kqueue.inc
+    )
+elseif (NN_HAVE_POLL)
+    add_definitions (-DNN_USE_POLL)
+    list (APPEND NN_SOURCES
+        aio/poller.h
+        aio/poller.c
+        aio/poller_poll.h
+        aio/poller_poll.inc
+    )
+elseif (NN_HAVE_WINSOCK)
+    # No operation
+else ()
+    message (AUTHOR_WARNING "ERROR: could not determine socket polling mechanism.")
+    message (AUTHOR_WARNING "${ISSUE_REPORT_MSG}" )
+endif ()
 
-add_definitions (-DNN_EXPORTS)
+if (NN_HAVE_EVENTFD)
+    add_definitions (-DNN_USE_EVENTFD)
+    list (APPEND NN_SOURCES
+        utils/efd_eventfd.h
+        utils/efd_eventfd.inc
+    )
+elseif (NN_HAVE_PIPE)
+    add_definitions (-DNN_USE_PIPE)
+    list (APPEND NN_SOURCES
+        utils/efd_pipe.h
+        utils/efd_pipe.inc
+    )
+elseif (NN_HAVE_SOCKETPAIR)
+    add_definitions (-DNN_USE_SOCKETPAIR)
+    list (APPEND NN_SOURCES
+        utils/efd_socketpair.h
+        utils/efd_socketpair.inc
+    )
+elseif (NN_HAVE_WINSOCK)
+    add_definitions (-DNN_USE_WINSOCK)
+    list (APPEND NN_SOURCES
+        utils/efd_win.h
+        utils/efd_win.inc
+    )
+else ()
+    message (AUTHOR_WARNING "ERROR: could not determine socket signalling mechanism.")
+    message (AUTHOR_WARNING "${ISSUE_REPORT_MSG}" )
+endif ()
 
-target_link_libraries (nanomsg ws2_32)
-target_link_libraries (nanomsg mswsock)
-target_link_libraries (nanomsg advapi32)
+# Provide same folder structure in IDE as on disk
+foreach (f ${NN_SOURCES})
+    # Get the path of the file relative to source directory
+    if (IS_ABSOLUTE "${f}")
+        file (RELATIVE_PATH f ${CMAKE_CURRENT_SOURCE_DIR} ${f})
+    endif ()
+    set (SRC_GROUP "${f}")
+    set (f "${CMAKE_CURRENT_SOURCE_DIR}/${f}")
 
-install(TARGETS nanomsg
+    # Remove the filename part
+    string (REGEX REPLACE "(.*)(/[^/]*)$" "\\1" SRC_GROUP ${SRC_GROUP})
+
+    # CMake source_group expects \\, not /
+    string (REPLACE / \\ SRC_GROUP ${SRC_GROUP})
+    source_group ("${SRC_GROUP}" FILES ${f})
+endforeach ()
+
+if (NN_STATIC_LIB)
+    add_library (${PROJECT_NAME} STATIC ${NN_SOURCES})
+    add_definitions (-DNN_STATIC_LIB)
+else ()
+    add_library (${PROJECT_NAME} SHARED ${NN_SOURCES})
+    add_definitions (-DNN_SHARED_LIB)
+    set_target_properties (${PROJECT_NAME} PROPERTIES
+        VERSION "${NN_PACKAGE_VERSION}"
+        SOVERSION "${NN_ABI_VERSION}")
+endif ()
+
+if (WIN32)
+    target_link_libraries (${PROJECT_NAME} ws2_32)
+    target_link_libraries (${PROJECT_NAME} mswsock)
+    target_link_libraries (${PROJECT_NAME} advapi32)
+elseif (UNIX)
+    if(THREADS_HAVE_PTHREAD_ARG)
+        add_definitions (-pthread)
+    endif()
+    if(CMAKE_THREAD_LIBS_INIT)
+        target_link_libraries (${PROJECT_NAME} "${CMAKE_THREAD_LIBS_INIT}")
+    endif()
+else ()
+    message (FATAL_ERROR "Assertion failed; this path is unreachable.")
+endif ()
+
+install (TARGETS ${PROJECT_NAME}
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin)
+    RUNTIME DESTINATION bin
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -350,6 +350,11 @@ else ()
         SOVERSION "${NN_ABI_VERSION}")
 endif ()
 
+# Set library outputs same as top-level project binary outputs
+set_target_properties (${PROJECT_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+set_target_properties (${PROJECT_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+set_target_properties (${PROJECT_NAME} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+
 if (WIN32)
     target_link_libraries (${PROJECT_NAME} ws2_32)
     target_link_libraries (${PROJECT_NAME} mswsock)

--- a/src/aio/poller.c
+++ b/src/aio/poller.c
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012 Martin Sustrik  All rights reserved.
+    Copyright (c) 2015-2016 Jack R. Dunaway.  All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -22,14 +23,12 @@
 
 #include "poller.h"
 
-#if !defined NN_HAVE_WINDOWS
-
-#if defined NN_USE_POLL
-#include "poller_poll.inc"
-#elif defined NN_USE_EPOLL
-#include "poller_epoll.inc"
+#if defined NN_USE_EPOLL
+    #include "poller_epoll.inc"
 #elif defined NN_USE_KQUEUE
-#include "poller_kqueue.inc"
-#endif
-
+    #include "poller_kqueue.inc"
+#elif defined NN_USE_POLL
+    #include "poller_poll.inc"
+#else
+    #error
 #endif

--- a/src/aio/poller.h
+++ b/src/aio/poller.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
+    Copyright (c) 2015-2016 Jack R. Dunaway.  All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -23,18 +24,18 @@
 #ifndef NN_POLLER_INCLUDED
 #define NN_POLLER_INCLUDED
 
-#if !defined NN_HAVE_WINDOWS
-
 #define NN_POLLER_IN 1
 #define NN_POLLER_OUT 2
 #define NN_POLLER_ERR 3
 
-#if defined NN_USE_POLL
-#include "poller_poll.h"
-#elif defined NN_USE_EPOLL
-#include "poller_epoll.h"
+#if defined NN_USE_EPOLL
+    #include "poller_epoll.h"
 #elif defined NN_USE_KQUEUE
-#include "poller_kqueue.h"
+    #include "poller_kqueue.h"
+#elif defined NN_USE_POLL
+    #include "poller_poll.h"
+#else
+    #error
 #endif
 
 int nn_poller_init (struct nn_poller *self);
@@ -51,6 +52,3 @@ int nn_poller_event (struct nn_poller *self, int *event,
     struct nn_poller_hndl **hndl);
 
 #endif
-
-#endif
-

--- a/src/nn.h
+++ b/src/nn.h
@@ -1,7 +1,8 @@
 /*
     Copyright (c) 2012-2014 Martin Sustrik  All rights reserved.
     Copyright (c) 2013 GoPivotal, Inc.  All rights reserved.
-    Copyright 2016 Garrett D'Amore <garrett@damore.org>
+    Copyright 2015-2016 Garrett D'Amore <garrett@damore.org>
+    Copyright (c) 2015-2016 Jack R. Dunaway.  All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -33,12 +34,14 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
-/*  Handle DSO symbol visibility                                             */
+/*  Handle DSO symbol visibility. */
 #if defined NN_NO_EXPORTS
 #   define NN_EXPORT
 #else
 #   if defined _WIN32
-#      if defined NN_EXPORTS
+#      if defined NN_STATIC_LIB
+#          define NN_EXPORT extern
+#      elif defined NN_SHARED_LIB
 #          define NN_EXPORT __declspec(dllexport)
 #      else
 #          define NN_EXPORT __declspec(dllimport)

--- a/src/utils/efd.c
+++ b/src/utils/efd.c
@@ -1,6 +1,7 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
     Copyright 2015 Garrett D'Amore <garrett@damore.org>
+    Copyright (c) 2015-2016 Jack R. Dunaway.  All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -23,16 +24,16 @@
 
 #include "efd.h"
 
-#if defined NN_HAVE_WINDOWS
-#include "efd_win.inc"
-#elif defined NN_HAVE_EVENTFD
-#include "efd_eventfd.inc"
-#elif defined NN_HAVE_PIPE
-#include "efd_pipe.inc"
-#elif defined NN_HAVE_SOCKETPAIR
-#include "efd_socketpair.inc"
+#if defined NN_USE_EVENTFD
+    #include "efd_eventfd.inc"
+#elif defined NN_USE_PIPE
+    #include "efd_pipe.inc"
+#elif defined NN_USE_SOCKETPAIR
+    #include "efd_socketpair.inc"
+#elif defined NN_USE_WINSOCK
+    #include "efd_win.inc"
 #else
-#error
+    #error
 #endif
 
 #if defined NN_HAVE_POLL
@@ -78,7 +79,7 @@ int nn_efd_wait (struct nn_efd *self, int timeout)
     if (nn_slow (rc == SOCKET_ERROR)) {
         rc = nn_err_wsa_to_posix (WSAGetLastError ());
         errno = rc;
-        
+
         /*  Treat these as a non-fatal errors, typically occuring when the
             socket is being closed from a separate thread during a blocking
             I/O operation. */
@@ -94,5 +95,5 @@ int nn_efd_wait (struct nn_efd *self, int timeout)
 }
 
 #else
-#error
+    #error
 #endif

--- a/src/utils/efd.h
+++ b/src/utils/efd.h
@@ -1,6 +1,7 @@
 /*
     Copyright (c) 2012-2013 Martin Sustrik  All rights reserved.
     Copyright 2015 Garrett D'Amore <garrett@damore.org>
+    Copyright (c) 2015-2016 Jack R. Dunaway.  All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -30,16 +31,16 @@
 
 #include "fd.h"
 
-#if defined NN_HAVE_WINDOWS
-#include "efd_win.h"
-#elif defined NN_HAVE_EVENTFD
-#include "efd_eventfd.h"
-#elif defined NN_HAVE_PIPE
-#include "efd_pipe.h"
-#elif defined NN_HAVE_SOCKETPAIR
-#include "efd_socketpair.h"
+#if defined NN_USE_EVENTFD
+    #include "efd_eventfd.h"
+#elif defined NN_USE_PIPE
+    #include "efd_pipe.h"
+#elif defined NN_USE_SOCKETPAIR
+    #include "efd_socketpair.h"
+#elif defined NN_USE_WINSOCK
+    #include "efd_win.h"
 #else
-#error
+    #error
 #endif
 
 /*  Initialise the efd object. */
@@ -67,4 +68,3 @@ void nn_efd_unsignal (struct nn_efd *self);
 int nn_efd_wait (struct nn_efd *self, int timeout);
 
 #endif
-


### PR DESCRIPTION
This pull request is meant to unify all platforms into a single CMake build system, in order to eventually deprecate the autotools toolchain.

This PR is the second attempt at squashing and rebasing CMake work from several branches that has diverged from mainline for several months, and includes feedback discussed on GitHub from @gdamore, @Snaipe, and @shiva. Discussion may be found here: https://github.com/nanomsg/nanomsg/pull/636

Substantial portions of this commit are attributed to both @shiva and @Snaipe, whom have both expressed their understanding squashing all work into a single commit while wrangling together this work from disparate sources. Thank you kindly for helping on this!