### PR TITLE
fixes #640 clock_rdtsc is unsafe

### DIFF
--- a/src/aio/timerset.h
+++ b/src/aio/timerset.h
@@ -23,7 +23,8 @@
 #ifndef NN_TIMERSET_INCLUDED
 #define NN_TIMERSET_INCLUDED
 
-#include "../utils/clock.h"
+#include <stdint.h>
+
 #include "../utils/list.h"
 
 /*  This class stores a list of timeouts and reports the next one to expire
@@ -35,7 +36,6 @@ struct nn_timerset_hndl {
 };
 
 struct nn_timerset {
-    struct nn_clock clock;
     struct nn_list timeouts;
 };
 

--- a/src/core/sock.c
+++ b/src/core/sock.c
@@ -31,6 +31,7 @@
 
 #include "../utils/err.h"
 #include "../utils/cont.h"
+#include "../utils/clock.h"
 #include "../utils/fast.h"
 #include "../utils/alloc.h"
 #include "../utils/msg.h"
@@ -119,7 +120,6 @@ int nn_sock_init (struct nn_sock *self, struct nn_socktype *socktype, int fd)
 
     self->holds = 1;   /*  Callers hold. */
     self->flags = 0;
-    nn_clock_init (&self->clock);
     nn_list_init (&self->eps);
     nn_list_init (&self->sdeps);
     self->eid = 1;
@@ -253,7 +253,6 @@ int nn_sock_term (struct nn_sock *self)
     nn_sem_term (&self->termsem);
     nn_list_term (&self->sdeps);
     nn_list_term (&self->eps);
-    nn_clock_term (&self->clock);
     nn_ctx_term (&self->ctx);
 
     /*  Destroy any optsets associated with the socket. */
@@ -598,7 +597,7 @@ int nn_sock_send (struct nn_sock *self, struct nn_msg *msg, int flags)
         timeout = -1;
     }
     else {
-        deadline = nn_clock_now (&self->clock) + self->sndtimeo;
+        deadline = nn_clock_ms() + self->sndtimeo;
         timeout = self->sndtimeo;
     }
 
@@ -670,7 +669,7 @@ int nn_sock_send (struct nn_sock *self, struct nn_msg *msg, int flags)
         /*  If needed, re-compute the timeout to reflect the time that have
             already elapsed. */
         if (self->sndtimeo >= 0) {
-            now = nn_clock_now (&self->clock);
+            now = nn_clock_ms();
             timeout = (int) (now > deadline ? 0 : deadline - now);
         }
     }
@@ -695,7 +694,7 @@ int nn_sock_recv (struct nn_sock *self, struct nn_msg *msg, int flags)
         timeout = -1;
     }
     else {
-        deadline = nn_clock_now (&self->clock) + self->rcvtimeo;
+        deadline = nn_clock_ms() + self->rcvtimeo;
         timeout = self->rcvtimeo;
     }
 
@@ -767,7 +766,7 @@ int nn_sock_recv (struct nn_sock *self, struct nn_msg *msg, int flags)
         /*  If needed, re-compute the timeout to reflect the time that have
             already elapsed. */
         if (self->rcvtimeo >= 0) {
-            now = nn_clock_now (&self->clock);
+            now = nn_clock_ms();
             timeout = (int) (now > deadline ? 0 : deadline - now);
         }
     }

--- a/src/core/sock.h
+++ b/src/core/sock.h
@@ -32,7 +32,6 @@
 
 #include "../utils/efd.h"
 #include "../utils/sem.h"
-#include "../utils/clock.h"
 #include "../utils/list.h"
 
 struct nn_pipe;
@@ -59,10 +58,6 @@ struct nn_sock
     struct nn_efd rcvfd;
     struct nn_sem termsem;
     struct nn_sem relesem;
-
-    /*  TODO: This clock can be accessed from different threads. If RDTSC
-        is out-of-sync among different CPU cores, this can be a problem. */
-    struct nn_clock clock;
 
     /*  List of all endpoints associated with the socket. */
     struct nn_list eps;

--- a/src/utils/clock.h
+++ b/src/utils/clock.h
@@ -25,27 +25,8 @@
 
 #include <stdint.h>
 
-/*  Optimised retrieval of the current time. The clock object is not
-    thread-safe. */
-
-struct nn_clock
-{
-    uint64_t last_tsc;
-    uint64_t last_time;
-};
-
-/*  Initialise the clock object. */
-void nn_clock_init (struct nn_clock *self);
-
-/*  Terminate the clock object. */
-void nn_clock_term (struct nn_clock *self);
-
 /*  Returns current time in milliseconds. */
-uint64_t nn_clock_now (struct nn_clock *self);
-
-/*  Returns an unique timestamp. If the system doesn't support producing
-    timestamps the return value is zero. */
-uint64_t nn_clock_timestamp ();
+uint64_t nn_clock_ms (void);
 
 #endif
 

--- a/src/utils/random.c
+++ b/src/utils/random.c
@@ -48,7 +48,7 @@ void nn_random_seed ()
     /*  The initial state for pseudo-random number generator is computed from
         the exact timestamp and process ID. */
     memcpy (&nn_random_state, "\xfa\x9b\x23\xe3\x07\xcc\x61\x1f", 8);
-    nn_random_state ^= pid + nn_clock_timestamp ();
+    nn_random_state ^= pid + nn_clock_ms();
 }
 
 void nn_random_generate (void *buf, size_t len)

--- a/tools/nanocat.c
+++ b/tools/nanocat.c
@@ -474,13 +474,11 @@ void nn_send_loop (nn_options_t *options, int sock)
     int rc;
     uint64_t start_time;
     int64_t time_to_sleep, interval;
-    struct nn_clock clock;
 
     interval = (int)(options->send_interval*1000);
-    nn_clock_init (&clock);
 
     for (;;) {
-        start_time = nn_clock_now (&clock);
+        start_time = nn_clock_ms();
         rc = nn_send (sock,
             options->data_to_send.data, options->data_to_send.length,
             0);
@@ -490,7 +488,7 @@ void nn_send_loop (nn_options_t *options, int sock)
             nn_assert_errno (rc >= 0, "Can't send");
         }
         if (interval >= 0) {
-            time_to_sleep = (start_time + interval) - nn_clock_now (&clock);
+            time_to_sleep = (start_time + interval) - nn_clock_ms();
             if (time_to_sleep > 0) {
                 nn_sleep ((int) time_to_sleep);
             }
@@ -498,8 +496,6 @@ void nn_send_loop (nn_options_t *options, int sock)
             break;
         }
     }
-
-    nn_clock_term(&clock);
 }
 
 void nn_recv_loop (nn_options_t *options, int sock)
@@ -527,14 +523,12 @@ void nn_rw_loop (nn_options_t *options, int sock)
     void *buf;
     uint64_t start_time;
     int64_t time_to_sleep, interval, recv_timeout;
-    struct nn_clock clock;
 
     interval = (int)(options->send_interval*1000);
     recv_timeout = (int)(options->recv_timeout*1000);
-    nn_clock_init (&clock);
 
     for (;;) {
-        start_time = nn_clock_now (&clock);
+        start_time = nn_clock_ms();
         rc = nn_send (sock,
             options->data_to_send.data, options->data_to_send.length,
             0);
@@ -549,7 +543,7 @@ void nn_rw_loop (nn_options_t *options, int sock)
         }
 
         for (;;) {
-            time_to_sleep = (start_time + interval) - nn_clock_now (&clock);
+            time_to_sleep = (start_time + interval) - nn_clock_ms();
             if (time_to_sleep <= 0) {
                 break;
             }
@@ -563,8 +557,7 @@ void nn_rw_loop (nn_options_t *options, int sock)
                 if (errno == EAGAIN) {
                     continue;
                 } else if (errno == ETIMEDOUT || errno == EFSM) {
-                    time_to_sleep = (start_time + interval)
-                        - nn_clock_now (&clock);
+                    time_to_sleep = (start_time + interval) - nn_clock_ms();
                     if (time_to_sleep > 0)
                         nn_sleep ((int) time_to_sleep);
                     continue;
@@ -575,8 +568,6 @@ void nn_rw_loop (nn_options_t *options, int sock)
             nn_freemsg (buf);
         }
     }
-
-    nn_clock_term(&clock);
 }
 
 void nn_resp_loop (nn_options_t *options, int sock)


### PR DESCRIPTION
While here, we can simplify the clock calls, since we don't need any state per clock.  Just return an absolute number of msec since arbitrary point in the past.

The main point of this change is to remove the broken premature optimizations around the TSC.  The operating systems in question are expected to provide sane, efficient, ways to determine the number of milliseconds since a point in the past (typically system boot).  Furthermore, we don't really need to have super accurate data here -- system clock granularity is more than sufficient since we aren't profiling or using this for super-resolution event timing; indeed even the bad case of 16 msec resolution some Windows systems have with GetTick64 would probably be sufficient for our needs.  (That said, we use QueryPerformanceCounter instead -- mostly because its more widely available than GetTick64.)