### PR TITLE
Removing two unused variables (two warnings from #639)

### DIFF
--- a/src/core/global.c
+++ b/src/core/global.c
@@ -173,7 +173,6 @@ static void nn_global_init (void)
     int i;
     char *envvar;
     int rc;
-    char *addr;
 
 #if defined NN_HAVE_WINDOWS
     WSADATA data;

--- a/src/transports/ws/cws.c
+++ b/src/transports/ws/cws.c
@@ -97,7 +97,7 @@ struct nn_cws {
     struct nn_chunkref remote_host;
     struct nn_chunkref nic;
     int remote_port;
-    int remote_hostname_len;
+    size_t remote_hostname_len;
 
     /*  If a close handshake is performed, this flag signals to not
         begin automatic reconnect retries. */

--- a/src/transports/ws/sws.c
+++ b/src/transports/ws/sws.c
@@ -574,7 +574,7 @@ static void nn_sws_validate_utf8_chunk (struct nn_sws *self)
 {
     uint8_t *pos;
     int code_point_len;
-    int len;
+    size_t len;
 
     len = self->inmsg_current_chunk_len;
     pos = self->inmsg_current_chunk_buf;
@@ -631,9 +631,9 @@ static void nn_sws_validate_utf8_chunk (struct nn_sws *self)
 
         if (code_point_len > 0) {
             /*  Valid code point found; continue validating. */
-            pos += code_point_len;
+            nn_assert (len >= code_point_len);
             len -= code_point_len;
-            nn_assert (len >= 0);
+            pos += code_point_len;
             continue;
         }
         else if (code_point_len == NN_SWS_UTF8_INVALID) {

--- a/src/transports/ws/ws_handshake.c
+++ b/src/transports/ws/ws_handshake.c
@@ -391,7 +391,7 @@ static void nn_ws_handshake_handler (struct nn_fsm *self, int src, int type,
 {
     struct nn_ws_handshake *handshaker;
 
-    unsigned i;
+    size_t i;
 
     handshaker = nn_cont (self, struct nn_ws_handshake, fsm);
 

--- a/tests/stats.c
+++ b/tests/stats.c
@@ -29,7 +29,6 @@
 
 int main (int argc, char **argv)
 {
-    int rc;
     int rep1;
     int req1;
 


### PR DESCRIPTION
Related to #639, this commit removes two unused variables caught by the MSVC compiler on AppVeyor: https://ci.appveyor.com/project/gdamore/nanomsg/build/0.8.410/job/09bx1jujs4bsqnqb#L1421