### PR TITLE
Added cmake option to build a static library using position-independent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ include (CheckSymbolExists)
 include (CheckStructHasMember)
 include (CheckLibraryExists)
 include (CheckCSourceCompiles)
+include (CheckCCompilerFlags)
 
 project (nanomsg C)
 enable_testing ()
@@ -85,6 +86,7 @@ endif()
 option (NN_ENABLE_NANOCAT "Enable building nanocat utility." ON)
 option (NN_STATIC_LIB "Build static library instead of shared library." OFF)
 option (NN_ENABLE_GETADDRINFO_A "Enable/disable use of getaddrinfo_a in place of getaddrinfo." ON)
+option (NN_ENABLE_PIC "Enable position-independent code when building static library" ON)
 
 #  Platform checks.
 
@@ -171,6 +173,8 @@ nn_check_sym (CLOCK_MONOTONIC time.h NN_HAVE_CLOCK_MONOTONIC)
 nn_check_sym (atomic_cas_32 atomic.h NN_HAVE_ATOMIC_SOLARIS)
 
 nn_check_struct_member(msghdr msg_control sys/socket.h NN_HAVE_MSG_CONTROL)
+
+check_c_compiler_flag ("-fPIC -Werror" NN_HAVE_FPIC)
 
 if (NN_HAVE_SEMAPHORE_RT OR NN_HAVE_SEMAPHORE_PTHREAD)
     add_definitions (-DNN_HAVE_SEMAPHORE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -340,6 +340,10 @@ foreach (f ${NN_SOURCES})
 endforeach ()
 
 if (NN_STATIC_LIB)
+    if (NN_HAVE_FPIC AND NN_ENABLE_PIC)
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+    endif ()
+
     add_library (${PROJECT_NAME} STATIC ${NN_SOURCES})
     add_definitions (-DNN_STATIC_LIB)
 else ()


### PR DESCRIPTION
This is a follow-up of #588. Autotools has the concept of "convenience libraries", i.e. static library built with position-independent code; and unfortunately, CMake doesn't. This is a problem, because it becomes impossible to link a the static nanomsg library into a shared library.

This PR fixes this by introducing a compiler check for `-fPIC` and adding it to the CFLAGS if found.

Because position-independent code can have some overhead, the PR also introduces the `NN_ENABLE_PIC` option to enable/disable this behaviour. The option is also on by default, because I think that being able to Just Work™ is more important by default than having an almost not noticeable overhead, and applications that absolutely *need* to disable that can still do so in their build.