### PR TITLE
fixes #660 enable asciidoctor documenation generation in cmake

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,19 +2,27 @@ version: 0.8.{build}
 environment:
   matrix:
     # array of all environments used to test builds
+    - GENERATOR: NMake Makefiles
+      CFG: Debug
+      VS_VERSION: 12.0
     - GENERATOR: Visual Studio 14 2015
+      VS_VERSION: 14.0
       CFG: Debug
     - GENERATOR: Visual Studio 12 2013
+      VS_VERSION: 12.0
       CFG: Debug
     - GENERATOR: Visual Studio 14 2015 Win64
       CFG: Debug
+      VS_VERSION: 14.0
     - GENERATOR: Visual Studio 12 2013 Win64
       CFG: Debug
+      VS_VERSION: 12.0
 install:
   - gem install asciidoctor
 build:
   parallel: true
 build_script:
+  - cmd: IF NOT %VS_VERSION% == NONE call "C:/Program Files (x86)/Microsoft Visual Studio %VS_VERSION%/Common7/Tools/vsvars32.bat"
   - cmd: cmake --version
   - cmd: md build
   - cmd: cd build

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,8 @@ environment:
       CFG: Debug
     - GENERATOR: Visual Studio 12 2013 Win64
       CFG: Debug
+install:
+  - gem install asciidoctor
 build:
   parallel: true
 build_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
 #      compiler: gcc
     - os: osx
       compiler: clang
+before_script:
+  - gem install asciidoctor
 script:
   # Print all environment variables to aid in CI development
   - printenv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,11 +84,11 @@ endif()
 # User-defined options.
 
 option (NN_STATIC_LIB "Build static library instead of shared library." OFF)
+option (NN_ENABLE_DOC "Enable building documentation." ON)
 option (NN_ENABLE_GETADDRINFO_A "Enable/disable use of getaddrinfo_a in place of getaddrinfo." ON)
 option (NN_TESTS "Build and run nanomsg tests" ON)
 option (NN_TOOLS "Build nanomsg tools" ON)
 option (NN_ENABLE_NANOCAT "Enable building nanocat utility." ${NN_TOOLS})
-option (NN_ENABLE_DOC "Enable building documentation." ON)
 
 #  Platform checks.
 
@@ -207,12 +207,18 @@ if (NN_ENABLE_NANOCAT)
     target_link_libraries (nanocat ${PROJECT_NAME})
 endif ()
 
+find_program (ASCIIDOCTOR_EXE asciidoctor)
+if (NOT ASCIIDOCTOR_EXE)
+    message (WARNING "asciidoctor not found, skipping docs")
+    set (NN_ENABLE_DOC OFF)
+else ()
+    if (NN_ENABLE_DOC)
+        message (STATUS "Using asciidoctor at ${ASCIIDOCTOR_EXE}")
+    endif ()
+endif ()
+
 # Build the documenation
 if (NN_ENABLE_DOC)
-    find_program (ASCIIDOCTOR_EXE asciidoctor)
-    if (NOT ASCIIDOCTOR_EXE)
-        message (WARNING "asciidoctor not found, skipping docs")
-    endif ()
 
     set (NN_DOCDIR ${CMAKE_CURRENT_SOURCE_DIR}/doc)
     set (NN_STYLESHEET ${NN_DOCDIR}/stylesheet.css)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,14 @@
 #
 
 cmake_minimum_required (VERSION 2.8.7)
+
+project (nanomsg C)
 include (CheckFunctionExists)
 include (CheckSymbolExists)
 include (CheckStructHasMember)
 include (CheckLibraryExists)
 include (CheckCSourceCompiles)
-
-project (nanomsg C)
+include (GNUInstallDirs)
 
 set (ISSUE_REPORT_MSG "Please consider opening an issue at https://github.com/nanomsg/nanomsg with your findings")
 
@@ -87,6 +88,7 @@ option (NN_ENABLE_GETADDRINFO_A "Enable/disable use of getaddrinfo_a in place of
 option (NN_TESTS "Build and run nanomsg tests" ON)
 option (NN_TOOLS "Build nanomsg tools" ON)
 option (NN_ENABLE_NANOCAT "Enable building nanocat utility." ${NN_TOOLS})
+option (NN_ENABLE_DOC "Enable building documentation." ON)
 
 #  Platform checks.
 
@@ -205,6 +207,92 @@ if (NN_ENABLE_NANOCAT)
     target_link_libraries (nanocat ${PROJECT_NAME})
 endif ()
 
+# Build the documenation
+if (NN_ENABLE_DOC)
+    find_program (ASCIIDOCTOR_EXE asciidoctor)
+    if (NOT ASCIIDOCTOR_EXE)
+        message (WARNING "asciidoctor not found, skipping docs")
+    endif ()
+
+    set (NN_DOCDIR ${CMAKE_CURRENT_SOURCE_DIR}/doc)
+    set (NN_STYLESHEET ${NN_DOCDIR}/stylesheet.css)
+    set (NN_TITLE ${PROJECT_NAME} ${NN_PACKAGE_VERSION})
+    set (NN_A2M ${ASCIIDOCTOR_EXE} -b manpage -amanmanual='${NN_TITLE}')
+    set (NN_A2H ${ASCIIDOCTOR_EXE} -d manpage -b html5 -a stylesheeet=${NN_STYLESHEET} -aversion-label=${PROJECT_NAME} -arevnumber=${NN_PACKAGE_VERSION})
+
+    macro (add_libnanomsg_man NAME SECT)
+        add_custom_command (
+            OUTPUT ${NAME}.${SECT}
+            COMMAND ${NN_A2M} -o ${NAME}.${SECT} ${NN_DOCDIR}/${NAME}.txt
+            MAIN_DEPENDENCY ${NN_DOCDIR}/${NAME}.txt
+        )
+
+        add_custom_command (
+            OUTPUT ${NAME}.${SECT}.html
+            COMMAND ${NN_A2H} -o ${NAME}.${SECT}.html ${NN_DOCDIR}/${NAME}.txt
+            DEPENDS ${NN_STYLESHEET}
+            MAIN_DEPENDENCY ${NN_DOCDIR}/${NAME}.txt
+        )
+
+        set(NN_MANS ${NN_MANS} ${NAME}.${SECT})
+        set(NN_HTMLS ${NN_HTMLS} ${NAME}.${SECT}.html)
+
+        install (
+            FILES ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.${SECT}.html
+            DESTINATION ${CMAKE_INSTALL_DOCDIR}
+        )
+        install (
+            FILES ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.${SECT}
+            DESTINATION ${CMAKE_INSTALL_MANDIR}/man${SECT}
+        )
+
+    endmacro (add_libnanomsg_man)
+
+    if (NN_ENABLE_NANOCAT)
+        add_libnanomsg_man (nanocat 1)
+    endif ()
+
+    add_libnanomsg_man (nn_errno 3)
+    add_libnanomsg_man (nn_strerror 3)
+    add_libnanomsg_man (nn_symbol 3)
+    add_libnanomsg_man (nn_symbol_info 3)
+    add_libnanomsg_man (nn_allocmsg 3)
+    add_libnanomsg_man (nn_reallocmsg 3)
+    add_libnanomsg_man (nn_freemsg 3)
+    add_libnanomsg_man (nn_socket 3)
+    add_libnanomsg_man (nn_close 3)
+    add_libnanomsg_man (nn_get_statistic 3)
+    add_libnanomsg_man (nn_getsockopt 3)
+    add_libnanomsg_man (nn_setsockopt 3)
+    add_libnanomsg_man (nn_bind 3)
+    add_libnanomsg_man (nn_connect 3)
+    add_libnanomsg_man (nn_shutdown 3)
+    add_libnanomsg_man (nn_send 3)
+    add_libnanomsg_man (nn_recv 3)
+    add_libnanomsg_man (nn_sendmsg 3)
+    add_libnanomsg_man (nn_recvmsg 3)
+    add_libnanomsg_man (nn_device 3)
+    add_libnanomsg_man (nn_cmsg 3)
+    add_libnanomsg_man (nn_poll 3)
+
+    add_libnanomsg_man (nanomsg 7)
+    add_libnanomsg_man (nn_pair 7)
+    add_libnanomsg_man (nn_reqrep 7)
+    add_libnanomsg_man (nn_pubsub 7)
+    add_libnanomsg_man (nn_survey 7)
+    add_libnanomsg_man (nn_pipeline 7)
+    add_libnanomsg_man (nn_bus 7)
+    add_libnanomsg_man (nn_inproc 7)
+    add_libnanomsg_man (nn_ipc 7)
+    add_libnanomsg_man (nn_tcp 7)
+    add_libnanomsg_man (nn_ws 7)
+    add_libnanomsg_man (nn_env 7)
+
+     add_custom_target (man ALL DEPENDS ${NN_MANS})
+     add_custom_target (html ALL DEPENDS ${NN_HTMLS})
+
+endif ()
+
 #  Build unit tests.
 
 if (NN_TESTS)
@@ -306,6 +394,6 @@ if (NN_ENABLE_NANOCAT)
     install (TARGETS nanocat RUNTIME DESTINATION bin)
 endif()
 
-set (CPACK_GENERATOR "NSIS")
 set (CPACK_PACKAGE_NAME ${PROJECT_NAME})
+set (CPACK_PACKAGE_VERSION ${NN_PACKAGE_VERSION})
 include (CPack)


### PR DESCRIPTION
While here I did a couple of things:

1) Doc generation enabled by default if asciidoctor is present
2) relocate the definition of the project so that installdirs is correct
3) stop forcing NSIS -- CPack generator can be chosen as needed

