### PR TITLE
fixes #554 weird hang/crash & race against nn_term

### DIFF
--- a/src/devices/device.c
+++ b/src/devices/device.c
@@ -27,20 +27,13 @@
 #include "../utils/fast.h"
 #include "../utils/fd.h"
 #include "../utils/attr.h"
+#include "../utils/thread.h"
 #include "device.h"
 
 #include <string.h>
 
-#if defined NN_HAVE_WINDOWS
-#include "../utils/win.h"
-#elif defined NN_HAVE_POLL
-#include <poll.h>
-#else
-#error
-#endif
-
 int nn_custom_device(struct nn_device_recipe *device, int s1, int s2,
-    int flags) 
+    int flags)
 {
     return nn_device_entry (device, s1, s2, flags);
 }
@@ -51,7 +44,7 @@ int nn_device (int s1, int s2)
 }
 
 int nn_device_entry (struct nn_device_recipe *device, int s1, int s2,
-    NN_UNUSED int flags) 
+    NN_UNUSED int flags)
 {
     int rc;
     int op1;
@@ -182,18 +175,17 @@ int nn_device_entry (struct nn_device_recipe *device, int s1, int s2,
     /*  Two-directional device. */
     if (device->required_checks & NN_CHECK_ALLOW_BIDIRECTIONAL) {
         if (s1rcv != -1 && s1snd != -1 && s2rcv != -1 && s2snd != -1)
-            return nn_device_twoway (device, s1, s1rcv, s1snd,
-                s2, s2rcv, s2snd);
+            return nn_device_twoway (device, s1, s2);
     }
 
     if (device->required_checks & NN_CHECK_ALLOW_UNIDIRECTIONAL) {
         /*  Single-directional device passing messages from s1 to s2. */
         if (s1rcv != -1 && s1snd == -1 && s2rcv == -1 && s2snd != -1)
-            return nn_device_oneway (device,s1, s1rcv, s2, s2snd);
+            return nn_device_oneway (device, s1, s2);
 
         /*  Single-directional device passing messages from s2 to s1. */
         if (s1rcv == -1 && s1snd != -1 && s2rcv != -1 && s2snd == -1)
-            return nn_device_oneway (device,s2, s2rcv, s1, s1snd);
+            return nn_device_oneway (device, s2, s1);
     }
 
     /*  This should never happen. */
@@ -224,141 +216,56 @@ int nn_device_loopback (struct nn_device_recipe *device, int s)
     }
 }
 
-#if defined NN_HAVE_WINDOWS
-
-int nn_device_twoway (struct nn_device_recipe *device,
-    int s1, nn_fd s1rcv, nn_fd s1snd,
-    int s2, nn_fd s2rcv, nn_fd s2snd)
-{
+struct nn_device_forwarder_args {
+    struct nn_device_recipe *device;
+    int s1;
+    int s2;
     int rc;
-    fd_set fds;
-    int s1rcv_isready = 0;
-    int s1snd_isready = 0;
-    int s2rcv_isready = 0;
-    int s2snd_isready = 0;
+    int err;
+};
 
-    /*  Initialise the pollset. */
-    FD_ZERO (&fds);
-
+static void nn_device_forwarder (void *a)
+{
+    struct nn_device_forwarder_args *args = a;
     for (;;) {
-
-        /*  Wait for network events. Adjust the 'ready' events based
-            on the result. */
-        if (s1rcv_isready)
-            FD_CLR (s1rcv, &fds);
-        else
-            FD_SET (s1rcv, &fds);
-        if (s1snd_isready)
-            FD_CLR (s1snd, &fds);
-        else
-            FD_SET (s1snd, &fds);
-        if (s2rcv_isready)
-            FD_CLR (s2rcv, &fds);
-        else
-            FD_SET (s2rcv, &fds);
-        if (s2snd_isready)
-            FD_CLR (s2snd, &fds);
-        else
-            FD_SET (s2snd, &fds);
-        rc = select (0, &fds, NULL, NULL, NULL);
-        if (nn_slow (rc == SOCKET_ERROR))
-            return -1;
-        if (FD_ISSET (s1rcv, &fds))
-            s1rcv_isready = 1;
-        if (FD_ISSET (s1snd, &fds))
-            s1snd_isready = 1;
-        if (FD_ISSET (s2rcv, &fds))
-            s2rcv_isready = 1;
-        if (FD_ISSET (s2snd, &fds))
-            s2snd_isready = 1;
-
-        /*  If possible, pass the message from s1 to s2. */
-        if (s1rcv_isready && s2snd_isready) {
-            rc = nn_device_mvmsg (device,s1, s2, NN_DONTWAIT);
-            if (nn_slow (rc < 0))
-                return -1;
-            s1rcv_isready = 0;
-            s2snd_isready = 0;
-        }
-
-        /*  If possible, pass the message from s2 to s1. */
-        if (s2rcv_isready && s1snd_isready) {
-            rc = nn_device_mvmsg (device,s2, s1, NN_DONTWAIT);
-            if (nn_slow (rc < 0))
-                return -1;
-            s2rcv_isready = 0;
-            s1snd_isready = 0;
+        args->rc = nn_device_mvmsg (args->device, args->s1, args->s2, 0);
+        if (nn_slow (args->rc < 0)) {
+            args->err = nn_errno ();
+            return;
         }
     }
 }
 
-#elif defined NN_HAVE_POLL
-
-int nn_device_twoway (struct nn_device_recipe *device,
-    int s1, nn_fd s1rcv, nn_fd s1snd,
-    int s2, nn_fd s2rcv, nn_fd s2snd)
+int nn_device_twoway (struct nn_device_recipe *device, int s1, int s2)
 {
-    int rc;
-    struct pollfd pfd [4];
+    struct nn_thread t1;
+    struct nn_thread t2;
+    struct nn_device_forwarder_args a1;
+    struct nn_device_forwarder_args a2;
 
-    /*  Initialise the pollset. */
-    pfd [0].fd = s1rcv;
-    pfd [0].events = POLLIN;
-    pfd [1].fd = s1snd;
-    pfd [1].events = POLLIN;
-    pfd [2].fd = s2rcv;
-    pfd [2].events = POLLIN;
-    pfd [3].fd = s2snd;
-    pfd [3].events = POLLIN;
+    a1.device = device;
+    a1.s1 = s1;
+    a1.s2 = s2;
 
-    for (;;) {
+    a2.device = device;
+    a2.s1 = s2;
+    a2.s2 = s1;
 
-        /*  Wait for network events. */
-        rc = poll (pfd, 4, -1);
-        if (nn_slow (rc < 0))
-            return -1;
+    nn_thread_init (&t1, nn_device_forwarder, &a1);
+    nn_thread_init (&t2, nn_device_forwarder, &a2);
 
-        /*  We had an infinite timeout, and have already checked for errors. */
-        nn_assert (rc != 0);
+    nn_thread_term (&t1);
+    nn_thread_term (&t2);
 
-        /*  Process the events. When the event is received, we cease polling
-            for it. */
-        if (pfd [0].revents & POLLIN)
-            pfd [0].events = 0;
-        if (pfd [1].revents & POLLIN)
-            pfd [1].events = 0;
-        if (pfd [2].revents & POLLIN)
-            pfd [2].events = 0;
-        if (pfd [3].revents & POLLIN)
-            pfd [3].events = 0;
-
-        /*  If possible, pass the message from s1 to s2. */
-        if (pfd [0].events == 0 && pfd [3].events == 0) {
-            rc = nn_device_mvmsg (device, s1, s2, NN_DONTWAIT);
-            if (nn_slow (rc < 0))
-                return -1;
-            pfd [0].events = POLLIN;
-            pfd [3].events = POLLIN;
-        }
-
-        /*  If possible, pass the message from s2 to s1. */
-        if (pfd [2].events == 0 && pfd [1].events == 0) {
-            rc = nn_device_mvmsg (device, s2, s1, NN_DONTWAIT);
-            if (nn_slow (rc < 0))
-                return -1;
-            pfd [2].events = POLLIN;
-            pfd [1].events = POLLIN;
-        }
+    if (a1.rc != 0) {
+        errno = a1.err;
+        return (a1.rc);
     }
+    errno = a2.err;
+    return a2.rc;
 }
 
-#else
-#error
-#endif
-
-int nn_device_oneway (struct nn_device_recipe *device,
-    int s1, NN_UNUSED nn_fd s1rcv,
-    int s2, NN_UNUSED nn_fd s2snd)
+int nn_device_oneway (struct nn_device_recipe *device, int s1, int s2)
 {
     int rc;
 
@@ -386,10 +293,11 @@ int nn_device_mvmsg (struct nn_device_recipe *device,
     hdr.msg_control = &control;
     hdr.msg_controllen = NN_MSG;
     rc = nn_recvmsg (from, &hdr, flags);
-    if (nn_slow (rc < 0 && (nn_errno () == ETERM || nn_errno () == EBADF)))
+    if (nn_slow (rc < 0 && (nn_errno () == ETERM || nn_errno () == EBADF))) {
         return -1;
+    }
     errno_assert (rc >= 0);
-    
+
     rc = device->nn_device_rewritemsg (device, from, to, flags, &hdr, rc);
     if (nn_slow (rc == -1))
         return -1;
@@ -398,16 +306,16 @@ int nn_device_mvmsg (struct nn_device_recipe *device,
     nn_assert(rc == 1);
 
     rc = nn_sendmsg (to, &hdr, flags);
-    if (nn_slow (rc < 0 && nn_errno () == ETERM))
+    if (nn_slow (rc < 0 && (nn_errno () == ETERM || nn_errno () == EBADF))) {
         return -1;
+    }
     errno_assert (rc >= 0);
     return 0;
 }
 
 int nn_device_rewritemsg (NN_UNUSED struct nn_device_recipe *device,
     NN_UNUSED int from, NN_UNUSED int to, NN_UNUSED int flags,
-    NN_UNUSED struct nn_msghdr *msghdr, NN_UNUSED int bytes) 
+    NN_UNUSED struct nn_msghdr *msghdr, NN_UNUSED int bytes)
 {
     return 1; /* always forward */
 }
-

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -34,12 +34,10 @@ struct nn_device_recipe {
         int s1, int s2, int flags);
 
     /*  The two-way poll function. */
-    int (*nn_device_twoway) (struct nn_device_recipe *device,
-        int s1, nn_fd s1rcv, nn_fd s1snd, int s2, nn_fd s2rcv, nn_fd s2snd);
+    int (*nn_device_twoway) (struct nn_device_recipe *device, int s1, int s2);
 
     /*  The one-way poll function. */
-    int (*nn_device_oneway) (struct nn_device_recipe *device,
-        int s1, nn_fd s1rcv, int s2, nn_fd s2snd);
+    int (*nn_device_oneway) (struct nn_device_recipe *device, int s1, int s2);
 
     int (*nn_device_loopback) (struct nn_device_recipe *device, int s);
 
@@ -72,10 +70,8 @@ struct nn_device_recipe {
 
 /*  Default implementations of the functions. */
 int nn_device_loopback (struct nn_device_recipe *device, int s);
-int nn_device_twoway (struct nn_device_recipe *device,
-    int s1, nn_fd s1rcv, nn_fd s1snd, int s2, nn_fd s2rcv, nn_fd s2snd);
-int nn_device_oneway (struct nn_device_recipe *device,
-    int s1, nn_fd s1rcv, int s2, nn_fd s2snd);
+int nn_device_twoway (struct nn_device_recipe *device, int s1, int s2);
+int nn_device_oneway (struct nn_device_recipe *device, int s1, int s2);
 int nn_device_mvmsg (struct nn_device_recipe *device,
     int from, int to, int flags);
 int nn_device_entry(struct nn_device_recipe *device,

--- a/tests/device.c
+++ b/tests/device.c
@@ -51,7 +51,7 @@ void device1 (NN_UNUSED void *arg)
 
     /*  Run the device. */
     rc = nn_device (deva, devb);
-    nn_assert (rc < 0 && (nn_errno () == ETERM || nn_errno () == EBADF));
+    nn_assert (rc < 0 && (nn_errno () == ETERM));
 
     /*  Clean up. */
     test_close (devb);


### PR DESCRIPTION
I *hope* this will solve the hangs and crashes against nn_term.  I've done a few things.

nn_recvmsg and nn_sendmsg check explicitly for the nn_term case on error paths (fixes up error returns from some EBADFD cases.)

nn_term() actually *closes* the sockets on exit -- this arranges for all their resources to reaped.  Before we leaked like a sieve.  And, worse, we didn't always shut things down, and we didn't wait at all for threads to shut down.  As a consequence of this, nn_term() may take longer than it did before.  This shouldn't matter because nn_term() ought *never* be on your hot code path, or you're doing something badly wrong.

To make this work, I had to create a custom version of nn_close() that proceeds even in the face of the zombification.  This is used internally by nn_term.  Also the nn_global_hold_socket_locked() got a new argument.

nn_device had some bugs here, and the use of of the poll fds to loop was pretty bad, and the code was non-portable.  Its been replaced with a simpler design using two threads, one in each direction.  In addition to much easier to read and validate code, there should be scalability improvements, and the code should actually run quite a lot faster as we have half as many system calls to execute for each message.

This is totally untested at this point -- I'm hoping to get some CI test coverage with this PR.