### PR TITLE
fixes #683 AppVeyor produces excessive warnings in MSVC builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,6 +36,10 @@ install:
       }
       gem install --no-document --local $asciidoctor
 
+# This section is a workaround for: https://github.com/nanomsg/nanomsg/issues/683
+before_build:
+  - del "C:\Program Files (x86)\MSBuild\%VS_VERSION%\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
+
 build:
   parallel: true
 build_script:


### PR DESCRIPTION
Testing advice from: http://help.appveyor.com/discussions/problems/4569-the-target-_convertpdbfiles-listed-in-a-beforetargets-attribute-at-c-does-not-exist-in-the-project-and-will-be-ignored#comment_39754176