### PR TITLE
Initial swag at condition variables.  For now we use this for dealing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,16 +82,18 @@ set (NN_SOURCES
     utils/err.c
     utils/fast.h
     utils/fd.h
-    utils/glock.h
-    utils/glock.c
     utils/hash.h
     utils/hash.c
     utils/list.h
     utils/list.c
     utils/msg.h
     utils/msg.c
+    utils/condvar.h
+    utils/condvar.c
     utils/mutex.h
     utils/mutex.c
+    utils/once.h
+    utils/once.c
     utils/queue.h
     utils/queue.c
     utils/random.h

--- a/src/core/global.c
+++ b/src/core/global.c
@@ -36,14 +36,14 @@
 #include "../utils/err.h"
 #include "../utils/alloc.h"
 #include "../utils/mutex.h"
+#include "../utils/condvar.h"
+#include "../utils/once.h"
 #include "../utils/list.h"
 #include "../utils/cont.h"
 #include "../utils/random.h"
-#include "../utils/glock.h"
 #include "../utils/chunk.h"
 #include "../utils/msg.h"
 #include "../utils/attr.h"
-#include "../utils/sleep.h"
 
 #include "../transports/inproc/inproc.h"
 #include "../transports/ipc/ipc.h"
@@ -135,10 +135,15 @@ struct nn_global {
     int state;
 
     int print_errors;
+
+    nn_mutex_t lock;
+    nn_condvar_t cond;
 };
 
 /*  Singleton object containing the global state of the library. */
 static struct nn_global self;
+static nn_once_t once = NN_ONCE_INITIALIZER;
+
 
 /*  Context creation- and termination-related private functions. */
 static void nn_global_init (void);
@@ -307,9 +312,9 @@ void nn_term (void)
 {
     int i;
 
-    nn_glock_lock ();
+    nn_mutex_lock (&self.lock);
     self.flags |= NN_CTX_FLAG_TERMING;
-    nn_glock_unlock ();
+    nn_mutex_unlock (&self.lock);
 
     /* Make sure we really close resources, this will cause global
        resources to be freed too when the last socket is closed. */
@@ -317,24 +322,22 @@ void nn_term (void)
         (void) nn_close (i);
     }
 
-    nn_glock_lock ();
+    nn_mutex_lock (&self.lock);
     self.flags |= NN_CTX_FLAG_TERMED;
     self.flags &= ~NN_CTX_FLAG_TERMING;
-    /*  TODO: Add a signal to wake nn_init ()  */
-    nn_glock_unlock ();
+    nn_condvar_broadcast(&self.cond);
+    nn_mutex_unlock (&self.lock);
 }
 
 void nn_init (void)
 {
-    nn_glock_lock ();
-    /*  Make sure any nn_term in progress is done. */
+    nn_mutex_lock (&self.lock);
+    /*  Wait for any in progress term to complete. */
     while (self.flags & NN_CTX_FLAG_TERMING) {
-        nn_glock_unlock ();
-        nn_sleep (100);
-        nn_glock_lock ();
+        nn_condvar_wait (&self.cond, &self.lock, -1);
     }
     self.flags &= ~NN_CTX_FLAG_TERMED;
-    nn_glock_unlock ();
+    nn_mutex_unlock (&self.lock);
 }
 
 void *nn_allocmsg (size_t size, int type)
@@ -418,7 +421,8 @@ int nn_global_create_socket (int domain, int protocol)
     struct nn_list_item *it;
     struct nn_socktype *socktype;
     struct nn_sock *sock;
-    /* The function is called with nn_glock held */
+
+    /* The function is called with lock held */
 
     /*  Only AF_SP and AF_SP_RAW domains are supported. */
     if (nn_slow (domain != AF_SP && domain != AF_SP_RAW)) {
@@ -457,15 +461,24 @@ int nn_global_create_socket (int domain, int protocol)
     return -EINVAL;
 }
 
+static void nn_lib_init(void)
+{
+    /*  This function is executed once to initialize global locks. */
+    nn_mutex_init (&self.lock);
+    nn_condvar_init (&self.cond);
+}
+
 int nn_socket (int domain, int protocol)
 {
     int rc;
 
-    nn_glock_lock ();
+    nn_do_once (&once, nn_lib_init);
+
+    nn_mutex_lock (&self.lock);
 
     /*  If nn_term() was already called, return ETERM. */
     if (nn_slow (self.flags & NN_CTX_FLAG_TERM)) {
-        nn_glock_unlock ();
+        nn_mutex_unlock (&self.lock);
         errno = ETERM;
         return -1;
     }
@@ -477,12 +490,12 @@ int nn_socket (int domain, int protocol)
 
     if (rc < 0) {
         nn_global_term ();
-        nn_glock_unlock ();
+        nn_mutex_unlock (&self.lock);
         errno = -rc;
         return -1;
     }
 
-    nn_glock_unlock();
+    nn_mutex_unlock (&self.lock);
 
     return rc;
 }
@@ -492,17 +505,17 @@ int nn_close (int s)
     int rc;
     struct nn_sock *sock;
 
-    nn_glock_lock ();
+    nn_mutex_lock (&self.lock);
     rc = nn_global_hold_socket_locked (&sock, s);
     if (nn_slow (rc < 0)) {
-        nn_glock_unlock ();
+        nn_mutex_unlock (&self.lock);
         errno = -rc;
         return -1;
     }
 
     /*  Start the shutdown process on the socket.  This will cause
         all other socket users, as well as endpoints, to begin cleaning up.
-        This is done with the glock held to ensure that two instances
+        This is done with the lock held to ensure that two instances
         of nn_close can't access the same socket. */
     nn_sock_stop (sock);
 
@@ -510,7 +523,7 @@ int nn_close (int s)
         the original hold, in order for nn_sock_term to complete. */
     nn_sock_rele (sock);
     nn_sock_rele (sock);
-    nn_glock_unlock ();
+    nn_mutex_unlock (&self.lock);
 
     /*  Now clean up.  The termination routine below will block until
         all other consumers of the socket have dropped their holds, and
@@ -524,7 +537,7 @@ int nn_close (int s)
 
     /*  Remove the socket from the socket table, add it to unused socket
         table. */
-    nn_glock_lock ();
+    nn_mutex_lock (&self.lock);
     self.socks [s] = NULL;
     self.unused [NN_MAX_SOCKETS - self.nsocks] = s;
     --self.nsocks;
@@ -533,7 +546,7 @@ int nn_close (int s)
     /*  Destroy the global context if there's no socket remaining. */
     nn_global_term ();
 
-    nn_glock_unlock ();
+    nn_mutex_unlock (&self.lock);
 
     return 0;
 }
@@ -1130,7 +1143,7 @@ int nn_global_print_errors ()
 }
 
 /*  Get the socket structure for a socket id.  This must be called under
-    the global lock (nn_glock_lock.)  The socket itself will not be freed
+    the global lock (self.lock.)  The socket itself will not be freed
     while the hold is active. */
 int nn_global_hold_socket_locked(struct nn_sock **sockp, int s)
 {
@@ -1154,15 +1167,15 @@ int nn_global_hold_socket_locked(struct nn_sock **sockp, int s)
 int nn_global_hold_socket(struct nn_sock **sockp, int s)
 {
     int rc;
-    nn_glock_lock();
+    nn_mutex_lock(&self.lock);
     rc = nn_global_hold_socket_locked(sockp, s);
-    nn_glock_unlock();
+    nn_mutex_unlock(&self.lock);
     return rc;
 }
 
 void nn_global_rele_socket(struct nn_sock *sock)
 {
-    nn_glock_lock();
+    nn_mutex_lock(&self.lock);
     nn_sock_rele(sock);
-    nn_glock_unlock();
+    nn_mutex_unlock(&self.lock);
 }

--- a/src/utils/condvar.c
+++ b/src/utils/condvar.c
@@ -1,0 +1,135 @@
+/*
+    Copyright 2016 Garrett D'Amore <garrett@damore.org>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom
+    the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#include "mutex.h"
+#include "condvar.h"
+#include "err.h"
+
+#if NN_HAVE_WINDOWS
+
+int nn_condvar_init (nn_condvar_t *cond)
+{
+    InitializeConditionVariable (&cond->cv);
+    return (0);
+}
+
+void nn_condvar_term (nn_condvar_t *cond)
+{
+}
+
+int nn_condvar_wait (nn_condvar_t *cond, nn_mutex_t *lock, int timeout)
+{
+    BOOL brc;
+    DWORD expire;
+
+    /*  Likely this is redundant, but for API correctness be explicit. */
+    expire = (timeout < 0) ? INFINITE : (DWORD) timeout;
+    brc = SleepConditionVariableCS (&cond->cv, &lock->mutex, expire);
+    if (!brc && GetLastError () == ERROR_TIMEOUT) {
+        return (-ETIMEDOUT);
+    }
+    return (0);
+}
+
+void nn_condvar_signal (nn_condvar_t *cond)
+{
+    WakeConditionVariable (&cond->cv);
+}
+
+void nn_condvar_broadcast (nn_condvar_t *cond)
+{
+    WakeAllConditionVariable (&cond->cv);
+}
+
+#else /* !NN_HAVE_WINDOWS */
+
+#include <sys/time.h>
+
+int nn_condvar_init (nn_condvar_t *cond)
+{
+    int rc;
+
+    /* This should really never fail, but the system may do so for
+       ENOMEM or EAGAIN due to resource exhaustion, or EBUSY if reusing
+       a condition variable with no intervening destroy call. */
+    rc = pthread_cond_init (&cond->cv, NULL);
+    return (-rc);
+}
+
+void nn_condvar_term (nn_condvar_t *cond)
+{
+    int rc;
+
+    /* This should never fail, the system is allowed to return EBUSY if
+       there are outstanding waiters (a serious bug!), or EINVAL if the
+       cv is somehow invalid or illegal.  Either of these cases would
+       represent a serious programming defect in our caller. */
+    rc = pthread_cond_destroy (&cond->cv);
+    errnum_assert (rc == 0, rc);
+}
+
+int nn_condvar_wait (nn_condvar_t *cond, nn_mutex_t *lock, int timeout)
+{
+    int rc;
+    struct timeval tv;
+    struct timespec ts;
+
+    if (timeout < 0) {
+        /*  This is an infinite sleep.  We don't care about return values,
+            as any error we can treat as just a premature wakeup. */
+        (void) pthread_cond_wait (&cond->cv, &lock->mutex);
+        return (0);
+    }
+
+    rc = gettimeofday(&tv, NULL);
+    errnum_assert (rc == 0, rc);
+
+    /* There are extra operations performed here, but they are done to avoid
+       wrap of the tv_usec and ts_nsec members on 32-bit systems. */
+    tv.tv_sec += timeout / 1000;
+    tv.tv_usec += (timeout % 1000) * 1000;
+
+    ts.tv_sec = tv.tv_sec + (tv.tv_usec / 1000000);
+    ts.tv_nsec = (tv.tv_usec % 1000000) * 1000;
+
+    rc = pthread_cond_timedwait (&cond->cv, &lock->mutex, &ts);
+    if (rc == ETIMEDOUT)
+        return (-ETIMEDOUT);
+    /* Treat all other cases (including errors) as normal wakeup. */
+    return (0);
+}
+
+void nn_condvar_signal (nn_condvar_t *cond)
+{
+    /* The only legal failure mode here is EINVAL if we passed a bad
+       condition variable.  We don't check that. */
+    (void) pthread_cond_signal (&cond->cv);
+}
+
+void nn_condvar_broadcast (nn_condvar_t *cond)
+{
+    /* The only legal failure mode here is EINVAL if we passed a bad
+       condition variable.  We don't check that. */
+    (void) pthread_cond_broadcast (&cond->cv);
+}
+
+#endif

--- a/src/utils/condvar.h
+++ b/src/utils/condvar.h
@@ -1,0 +1,67 @@
+/*
+    Copyright 2016 Garrett D'Amore <garrett@damore.org>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom
+    the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#ifndef NN_CONDVAR_INCLUDED
+#define NN_CONDVAR_INCLUDED
+
+#include "mutex.h"
+
+#ifdef NN_HAVE_WINDOWS
+#include "win.h"
+struct nn_condvar {
+    CONDITION_VARIABLE cv;
+};
+
+#else /* !NN_HAVE_WINDOWS */
+
+#include <pthread.h>
+
+struct nn_condvar {
+    pthread_cond_t cv;
+};
+
+#endif /* NN_HAVE_WINDOWS */
+
+typedef struct nn_condvar nn_condvar_t;
+
+/*  Initialise the condvar. */
+int nn_condvar_init (nn_condvar_t *cond);
+
+/*  Terminate the condvar. */
+void nn_condvar_term (nn_condvar_t *cond);
+
+/*  Sleep on a condition variable, with a possible timeout.  The mutex should
+    be held when calling, and will be dropped on entry and reacquired
+    atomically on return.  The caller will wake when signaled, or when the
+    timeout expires, but may be woken spuriously as well.  If the timeout
+    expires without a signal, -ETIMEDOUT will be returned, otherwise 0
+    will be returned.  If expire is < 0, then no timeout will be used,
+    representing a potentially infinite wait. */
+int nn_condvar_wait (nn_condvar_t *cond, nn_mutex_t *lock, int timeout);
+
+/*  Signal (wake) one condition variable waiter. */
+void nn_condvar_signal (nn_condvar_t *cond);
+
+/* Signal all condition variable waiters, waking all of them. */
+void nn_condvar_broadcast (nn_condvar_t *cond);
+
+#endif

--- a/src/utils/mutex.c
+++ b/src/utils/mutex.c
@@ -25,29 +25,29 @@
 
 #ifdef NN_HAVE_WINDOWS
 
-void nn_mutex_init (struct nn_mutex *self)
+void nn_mutex_init (nn_mutex_t *self)
 {
     InitializeCriticalSection (&self->mutex);
 }
 
-void nn_mutex_term (struct nn_mutex *self)
+void nn_mutex_term (nn_mutex_t *self)
 {
     DeleteCriticalSection (&self->mutex);
 }
 
-void nn_mutex_lock (struct nn_mutex *self)
+void nn_mutex_lock (nn_mutex_t *self)
 {
     EnterCriticalSection (&self->mutex);
 }
 
-void nn_mutex_unlock (struct nn_mutex *self)
+void nn_mutex_unlock (nn_mutex_t *self)
 {
     LeaveCriticalSection (&self->mutex);
 }
 
 #else
 
-void nn_mutex_init (struct nn_mutex *self)
+void nn_mutex_init (nn_mutex_t *self)
 {
     int rc;
 
@@ -55,7 +55,7 @@ void nn_mutex_init (struct nn_mutex *self)
     errnum_assert (rc == 0, rc);
 }
 
-void nn_mutex_term (struct nn_mutex *self)
+void nn_mutex_term (nn_mutex_t *self)
 {
     int rc;
 
@@ -63,7 +63,7 @@ void nn_mutex_term (struct nn_mutex *self)
     errnum_assert (rc == 0, rc);
 }
 
-void nn_mutex_lock (struct nn_mutex *self)
+void nn_mutex_lock (nn_mutex_t *self)
 {
     int rc;
 
@@ -71,7 +71,7 @@ void nn_mutex_lock (struct nn_mutex *self)
     errnum_assert (rc == 0, rc);
 }
 
-void nn_mutex_unlock (struct nn_mutex *self)
+void nn_mutex_unlock (nn_mutex_t *self)
 {
     int rc;
 

--- a/src/utils/mutex.h
+++ b/src/utils/mutex.h
@@ -30,6 +30,8 @@
 #endif
 
 struct nn_mutex {
+    /*  NB: The fields of this structure are private to the mutex
+        implementation. */
 #ifdef NN_HAVE_WINDOWS
     CRITICAL_SECTION mutex;
 #else
@@ -37,18 +39,19 @@ struct nn_mutex {
 #endif
 };
 
+typedef struct nn_mutex nn_mutex_t;
+
 /*  Initialise the mutex. */
-void nn_mutex_init (struct nn_mutex *self);
+void nn_mutex_init (nn_mutex_t *self);
 
 /*  Terminate the mutex. */
-void nn_mutex_term (struct nn_mutex *self);
+void nn_mutex_term (nn_mutex_t *self);
 
 /*  Lock the mutex. Behaviour of multiple locks from the same thread is
     undefined. */
-void nn_mutex_lock (struct nn_mutex *self);
+void nn_mutex_lock (nn_mutex_t *self);
 
 /*  Unlock the mutex. Behaviour of unlocking an unlocked mutex is undefined */
-void nn_mutex_unlock (struct nn_mutex *self);
+void nn_mutex_unlock (nn_mutex_t *self);
 
 #endif
-

--- a/src/utils/once.h
+++ b/src/utils/once.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2012 Martin Sustrik  All rights reserved.
+    Copyright 2016 Garrett D'Amore <garrett@damore.org>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -20,14 +20,28 @@
     IN THE SOFTWARE.
 */
 
-#ifndef NN_GLOCK_INCLUDED
-#define NN_GLOCK_INCLUDED
+#ifndef NN_ONCE_INCLUDED
+#define NN_ONCE_INCLUDED
 
-/*  Implementation of a global lock (critical section). The lock is meant to
-    be used to synchronise the initialisation/termination of the library. */
+#ifdef NN_HAVE_WINDOWS
+#include "win.h"
+struct nn_once {
+    INIT_ONCE once;
+};
+#define	NN_ONCE_INITIALIZER	{ INIT_ONCE_STATIC_INIT }
 
-void nn_glock_lock (void);
-void nn_glock_unlock (void);
+#else /* !NN_HAVE_WINDOWS */
 
-#endif
+#include <pthread.h>
 
+struct nn_once {
+    pthread_once_t once;
+};
+#define NN_ONCE_INITIALIZER	{ PTHREAD_ONCE_INIT }
+
+#endif /* NN_HAVE_WINDOWS */
+
+typedef struct nn_once nn_once_t;
+void nn_do_once (nn_once_t *once, void (*func)(void));
+
+#endif /* NN_ONCE_INCLUDED */


### PR DESCRIPTION
with nn_term, nn_init, and nn_socket synchronization.  This includes
definitions for nn_once_t and nn_condvar_t.  The former is required as
Windows lacks any kind of static initializer for CriticalSections.
So we have to use the nn_once_t to initialize the beginning library
functions.  We also replace the glock.

(This PR attempts to check for building & running this on Windows.  POSIX is already tested out.)