### PR TITLE
fixes #717 NN_STATIC_LIB not properly handled in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,14 @@ if (WIN32)
     set(NN_REQUIRED_LIBRARIES ${NN_REQUIRED_LIBRARIES} ws2_32)
     set(NN_REQUIRED_LIBRARIES ${NN_REQUIRED_LIBRARIES} mswsock)
     set(NN_REQUIRED_LIBRARIES ${NN_REQUIRED_LIBRARIES} advapi32)
+
+    # Ensure tests/tools built as EXE choose symbol visibility appropriate for
+    # linking the library, whether static or dynamic.
+    if (NN_STATIC_LIB)
+        add_definitions (-DNN_WIN32_LIB_LINK)
+    else ()
+        add_definitions (-DNN_WIN32_DLL_LINK)
+    endif ()
 else ()
     # Unconditionally declare the following feature test macros.  These are
     # needed for some platforms (glibc and SunOS/illumos) and should be harmless

--- a/src/nn.h
+++ b/src/nn.h
@@ -36,10 +36,14 @@ extern "C" {
 
 /*  Handle DSO symbol visibility. */
 #if !defined(NN_EXPORT)
-#    if defined(_WIN32) && !defined(NN_STATIC_LIB)
-#        if defined NN_SHARED_LIB
+#    if defined(_WIN32)
+#        if defined(NN_STATIC_LIB)
+#            define NN_EXPORT
+#        elif defined(NN_WIN32_LIB_LINK)
+#            define NN_EXPORT
+#        elif defined(NN_SHARED_LIB)
 #            define NN_EXPORT __declspec(dllexport)
-#        else
+#        else defined(NN_WIN32_DLL_LINK)
 #            define NN_EXPORT __declspec(dllimport)
 #        endif
 #    else


### PR DESCRIPTION
Note that also the definition of `NN_EXPORT` within `nn.h` has been tightened from `defined(_WIN32)` to `defined(NN_HAVE_MSVC)` for explicitness and correctness.