### PR TITLE
fixes #754 CMake may not find InitializeConditionVariable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,10 @@ elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
     set (NN_HAVE_WINSOCK 1)
     add_definitions (-DNN_HAVE_WINDOWS)
     add_definitions (-D_CRT_SECURE_NO_WARNINGS)
+
+    # Target Windows Vista and later
+    add_definitions (-D_WIN32_WINNT=0x0600)
+    list (APPEND CMAKE_REQUIRED_DEFINITIONS -D_WIN32_WINNT=0x0600)
 elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
     add_definitions (-DNN_HAVE_FREEBSD)
 elseif (CMAKE_SYSTEM_NAME MATCHES "NetBSD")


### PR DESCRIPTION
This explicitely tells the compiler that we target Windows Vista and later. Symbol checks on earlier versions of windows will fail regardless, since the linker won't be able to find the symbol even if it's declared.