### PR TITLE
free struct nn_btcp if binding has failed to avoid memory leak

### DIFF
--- a/src/transports/tcp/btcp.c
+++ b/src/transports/tcp/btcp.c
@@ -376,6 +376,7 @@ static int nn_btcp_listen (struct nn_btcp *self)
     rc = nn_usock_bind (&self->usock, (struct sockaddr*) &ss, (size_t) sslen);
     if (rc < 0) {
        nn_usock_stop (&self->usock);
+       nn_free(self);
        return rc;
     }
 


### PR DESCRIPTION
Hi,

I've found a memory leak in the lib and this little change was able to fix it for me.
The memory leak appeared when you try to bind a socket to a port which can't be bind.

Valgrind report this :
```c
16: ==13441== Thread 1:
16: ==13441== 747,720 bytes in 1,005 blocks are definitely lost in loss record 56 of 56
16: ==13441==    at 0x4C2ABD0: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
16: ==13441==    by 0x5360572: nn_alloc_ (in /usr/lib/libnanomsg.so.0969988-dirty)
16: ==13441==    by 0x5378D53: nn_btcp_create (in /usr/lib/libnanomsg.so.0969988-dirty)
16: ==13441==    by 0x537CA2D: nn_tcp_bind (in /usr/lib/libnanomsg.so.0969988-dirty)
16: ==13441==    by 0x5354848: nn_ep_init (in /usr/lib/libnanomsg.so.0969988-dirty)
16: ==13441==    by 0x5359121: nn_sock_add_ep (in /usr/lib/libnanomsg.so.0969988-dirty)
16: ==13441==    by 0x5356FF2: nn_global_create_ep (in /usr/lib/libnanomsg.so.0969988-dirty)
16: ==13441==    by 0x5355F01: nn_bind (in /usr/lib/libnanomsg.so.0969988-dirty)
```

The only memory allocation is :
```c
/* Allocate the new endpoint object. */ 
self = nn_alloc (sizeof (struct nn_btcp), "btcp"); 
alloc_assert (self);
```

After some search i was able to find where the lib does really bind the socket :
```c
rc = nn_usock_bind (&self->usock, (struct sockaddr*) &ss, (size_t) sslen); 
if (rc < 0) { 
 nn_usock_stop (&self->usock); 
 nn_free(self); 
 return rc; 
}
```

So I add the `nn_free(self);` to free memory and the leak has gone.
I don't know if it's the right way to clean this error, but it works for me so I propose this little change.

Thanks for this really good lib !
Olivier Radisson.