### PR TITLE
Removed obsolete windows XP and earlier code for inet_pton

### DIFF
--- a/src/transports/utils/literal.c
+++ b/src/transports/utils/literal.c
@@ -32,46 +32,6 @@
 #include <netinet/in.h>
 #endif
 
-/*  On Windows XS there's no inet_pton() function. */
-#if defined NN_HAVE_WINDOWS && ((_WIN32_WINNT <= 0x0501) || (WINVER <= 0x0501))
-
-static int nn_inet_pton(int family, const char *src, void *dst)
-{
-    int rc;
-    struct sockaddr_storage addr;
-    int addr_len = sizeof(addr);
-
-    if (nn_slow (family != AF_INET && family != AF_INET6)) {
-        errno = EAFNOSUPPORT;
-        return -1;
-    }
-
-    addr.ss_family = family;
-    rc = WSAStringToAddressA ((char*) src, family, NULL,
-        (struct sockaddr*) &addr, &addr_len);
-    if (rc != 0)
-        return 0;
-
-    if (family == AF_INET) {
-        memcpy(dst, &((struct sockaddr_in *) &addr)->sin_addr,
-            sizeof(struct in_addr));
-    } else if (family == AF_INET6) {
-        memcpy(dst, &((struct sockaddr_in6 *)&addr)->sin6_addr,
-            sizeof(struct in6_addr));
-    }
-
-    return 1;
-}
-
-#else
-
-static int nn_inet_pton(int family, const char *src, void *dst)
-{
-    return inet_pton (family, src, dst);
-}
-
-#endif
-
 int nn_literal_resolve (const char *addr, size_t addrlen,
     int ipv4only, struct sockaddr_storage *result, size_t *resultlen)
 {
@@ -101,7 +61,7 @@ int nn_literal_resolve (const char *addr, size_t addrlen,
 
     /*  Try to interpret the literal as an IPv6 address. */
     if (!ipv4only) {
-        rc = nn_inet_pton (AF_INET6, addrz, &in6addr);
+        rc = inet_pton (AF_INET6, addrz, &in6addr);
         if (rc == 1) {
             if (result) {
                 result->ss_family = AF_INET6;
@@ -115,7 +75,7 @@ int nn_literal_resolve (const char *addr, size_t addrlen,
     }
 
     /*  Try to interpret the literal as an IPv4 address. */
-    rc = nn_inet_pton (AF_INET, addrz, &inaddr);
+    rc = inet_pton (AF_INET, addrz, &inaddr);
     if (rc == 1) {
         if (result) {
            result->ss_family = AF_INET;


### PR DESCRIPTION
I just stumbed across this piece of code #ifdef'ed with _WIN32_WIN <= 501 (which means Windows XP & earlier). Since nanomsg does not support Windows versions earlier than Windows Vista, this code is obsolete and should be removed.