### PR TITLE
nanocat: implement to launch an executable for responder

### DIFF
--- a/doc/nanocat.txt
+++ b/doc/nanocat.txt
@@ -10,7 +10,7 @@ SYNOPSIS
 --------
 
     nanocat --req {--connect ADDR|--bind ADDR} {--data DATA|--file PATH} [-i SEC] [-AQ]
-    nanocat --rep {--connect ADDR|--bind ADDR} {--data DATA|--file PATH} [-AQ]
+    nanocat --rep {--connect ADDR|--bind ADDR} {--data DATA|--file PATH|--exec PATH} [-AQ]
     nanocat --push {--connect ADDR|--bind ADDR} {--data DATA|--file PATH} [-i SEC]
     nanocat --pull {--connect ADDR|--bind ADDR} [-AQ]
     nanocat --pub {--connect ADDR|--bind ADDR} {--data DATA|--file PATH} [-i SEC]
@@ -23,7 +23,7 @@ SYNOPSIS
 In the case symlinks are installed:
 
     nn_req {--connect ADDR|--bind ADDR} {--data DATA|--file PATH} [-i SEC] [-AQ]
-    nn_rep {--connect ADDR|--bind ADDR} {--data DATA|--file PATH} [-AQ]
+    nn_rep {--connect ADDR|--bind ADDR} {--data DATA|--file PATH|--exec PATH} [-AQ]
     nn_push {--connect ADDR|--bind ADDR} {--data DATA|--file PATH} [-i SEC]
     nn_pull {--connect ADDR|--bind ADDR} [-AQ]
     nn_pub {--connect ADDR|--bind ADDR} {--data DATA|--file PATH} [-i SEC]
@@ -132,7 +132,8 @@ Output Options:
     socket. Send DATA as request for REQ or SURVEYOR socket.
  *--file,-F* 'PATH'::
     Same as --data but get data from file PATH
-
+ *--exec,-E* 'PATH'::
+    Launch an executable after retrieving something from REP socket. 
 
 EXAMPLES
 --------
@@ -164,6 +165,9 @@ Send heartbeats to imaginary monitoring service:
 
     nanocat --pub --connect tpc://monitoring.example.org -D"I am alive!" --interval 10
 
+Launch an executable after retrieving something:
+
+    nanocat --rep --connect ipc:///var/run/app/req.socket -E 'ls -l'
 
 SEE ALSO
 --------

--- a/tools/options.c
+++ b/tools/options.c
@@ -29,6 +29,11 @@
 #include <assert.h>
 #include <errno.h>
 #include <ctype.h>
+#ifndef NN_HAVE_WINDOWS
+#include <unistd.h>
+#include <signal.h>
+#include <sys/types.h>
+#endif
 
 struct nn_parse_context {
     /*  Initial state  */
@@ -63,6 +68,9 @@ static int nn_has_arg (struct nn_option *opt)
         case NN_OPT_LIST_APPEND:
         case NN_OPT_LIST_APPEND_FMT:
         case NN_OPT_READ_FILE:
+#ifndef NN_HAVE_WINDOWS
+        case NN_OPT_EXEC:
+#endif
             return 1;
     }
     nn_assert (0);
@@ -385,6 +393,12 @@ static void nn_process_option (struct nn_parse_context *ctx,
     size_t data_len;
     size_t data_buf;
     size_t bytes_read;
+#ifndef NN_HAVE_WINDOWS
+    int argc;
+    char **argv;
+    char *args, *curr_arg;
+    struct nn_exec_data *exec_data;
+#endif
 
     opt = &ctx->options[opt_index];
     if (ctx->mask & opt->conflicts_mask) {
@@ -521,6 +535,57 @@ static void nn_process_option (struct nn_parse_context *ctx,
             blob->length = data_len;
             blob->need_free = 1;
             return;
+#ifndef NN_HAVE_WINDOWS
+        case NN_OPT_EXEC:
+            assert (signal (SIGPIPE,SIG_IGN) != SIG_ERR);
+
+            /* Construct argv[] for execvp() */
+            args = malloc (strlen(argument) + 1);
+            if (!args)
+                nn_memory_error (ctx);
+
+            memcpy (args, argument, strlen(argument) + 1);
+
+            argv = (char **) malloc (sizeof (char *));
+            if (!argv)
+                nn_memory_error (ctx);
+
+            argc = 0;
+            argv[0] = NULL;
+            curr_arg = args;
+            while (*curr_arg) {
+                char *prev_arg;
+
+                /* Skip preposed spaces */
+                while (*curr_arg && isspace (*curr_arg))
+                    ++curr_arg;
+
+                if (*curr_arg)
+                    prev_arg = curr_arg++;
+                else
+                    break;
+                
+                /* Skip characters */
+                while (*curr_arg && !isspace (*curr_arg))
+                    ++curr_arg;
+                
+                argv = realloc (argv, sizeof (char *) * (++argc + 1));
+                if (!argv)
+                    nn_memory_error (ctx);
+
+                argv[argc - 1] = prev_arg;
+                argv[argc] = NULL;
+
+                if (*curr_arg)
+                    *curr_arg++ = 0;
+            }
+
+            exec_data = (struct nn_exec_data *)(((char *)ctx->target) + opt->offset);
+            exec_data->argv = argv;
+            exec_data->args = args;
+
+            return;
+#endif
     }
     abort ();
 }
@@ -784,6 +849,9 @@ void nn_free_options (struct nn_commandline *cline, void *target) {
     struct nn_option *opt;
     struct nn_blob *blob;
     struct nn_string_list *lst;
+#ifndef NN_HAVE_WINDOWS
+    struct nn_exec_data *exec_data;
+#endif
 
     for (i = 0;; ++i) {
         opt = &cline->options[i];
@@ -814,6 +882,13 @@ void nn_free_options (struct nn_commandline *cline, void *target) {
                 blob->need_free = 0;
             }
             break;
+#ifndef NN_HAVE_WINDOWS
+        case NN_OPT_EXEC:
+            exec_data = (struct nn_exec_data *)(((char *)target) + opt->offset);
+            free(exec_data->argv);
+            free(exec_data->args);
+            break;
+#endif
         default:
             break;
         }

--- a/tools/options.h
+++ b/tools/options.h
@@ -37,7 +37,10 @@ enum nn_option_type {
     NN_OPT_FLOAT,
     NN_OPT_LIST_APPEND,
     NN_OPT_LIST_APPEND_FMT,
-    NN_OPT_READ_FILE
+    NN_OPT_READ_FILE,
+#ifndef NN_HAVE_WINDOWS
+    NN_OPT_EXEC,
+#endif
 };
 
 struct nn_option {
@@ -87,6 +90,12 @@ struct nn_blob {
     int need_free;
 };
 
+#ifndef NN_HAVE_WINDOWS
+struct nn_exec_data {
+    char **argv;
+    char *args;
+};
+#endif
 
 void nn_parse_options (struct nn_commandline *cline,
                       void *target, int argc, char **argv);


### PR DESCRIPTION
-E option allows to launch an executable for responder to handle the input from nn_recv() and output the resulting contents through nn_send().

Internally, a subprocess is used to launch the executable and its standard input and output are bound to the NN socket over a pipe.

Note this option currently is only avialable for Linux environment.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>