### PR TITLE
fix: nn_dns_check_hostname returns EINVAL for domain names with the dot at the end

### DIFF
--- a/src/transports/utils/dns.c
+++ b/src/transports/utils/dns.c
@@ -44,11 +44,6 @@ int nn_dns_check_hostname (const char *name, size_t namelen)
 
         /*  End of the hostname. */
         if (namelen == 0) {
-
-            /*  The last label cannot be empty. */
-            if (labelsz == 0)
-                return -EINVAL;
-
             /*  Success! */
             return 0;
         }


### PR DESCRIPTION
e.g. "example.com." were not accepted, although it is valid FQDN