### PR TITLE
Fix FQDN

### DIFF
--- a/src/transports/utils/dns.c
+++ b/src/transports/utils/dns.c
@@ -44,11 +44,6 @@ int nn_dns_check_hostname (const char *name, size_t namelen)
 
         /*  End of the hostname. */
         if (namelen == 0) {
-
-            /*  The last label cannot be empty. */
-            if (labelsz == 0)
-                return -EINVAL;
-
             /*  Success! */
             return 0;
         }

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -118,9 +118,6 @@ int main (int argc, const char *argv[])
     rc = nn_connect (sc, "tcp://[::1]:5555");
     nn_assert (rc < 0);
     errno_assert (nn_errno () == EINVAL);
-    rc = nn_connect (sc, "tcp://abc.123.:5555");
-    nn_assert (rc < 0);
-    errno_assert (nn_errno () == EINVAL);
     rc = nn_connect (sc, "tcp://abc...123:5555");
     nn_assert (rc < 0);
     errno_assert (nn_errno () == EINVAL);

--- a/tests/ws.c
+++ b/tests/ws.c
@@ -150,9 +150,6 @@ int main (int argc, const char *argv[])
     rc = nn_connect (sc, "ws://[::1]:5555");
     nn_assert (rc < 0);
     errno_assert (nn_errno () == EINVAL);
-    rc = nn_connect (sc, "ws://abc.123.:5555");
-    nn_assert (rc < 0);
-    errno_assert (nn_errno () == EINVAL);
     rc = nn_connect (sc, "ws://abc...123:5555");
     nn_assert (rc < 0);
     errno_assert (nn_errno () == EINVAL);


### PR DESCRIPTION
nn_dns_check_hostname returns EINVAL for domain names with the dot at the end.
e.g. "example.org." were not accepted, although it is valid FQDN.
