### PR TITLE
fixes #810 WS protocol has wrong fail_msg_len calculation

### DIFF
--- a/src/transports/ws/sws.c
+++ b/src/transports/ws/sws.c
@@ -815,6 +815,7 @@ static void nn_sws_fail_conn (struct nn_sws *self, int code, char *reason)
 
     /*  Copy Close Reason immediately following the code. */
     memcpy (payload_pos + NN_SWS_CLOSE_CODE_LEN, reason, reason_len);
+    self->fail_msg_len += reason_len;
 
     /*  If this is a client, apply mask. */
     if (self->mode == NN_WS_CLIENT) {
@@ -822,7 +823,6 @@ static void nn_sws_fail_conn (struct nn_sws *self, int code, char *reason)
             rand_mask, NN_SWS_FRAME_SIZE_MASK, NULL);
     }
 
-    self->fail_msg_len += payload_len;
 
     if (self->outstate == NN_SWS_OUTSTATE_IDLE) {
         iov.iov_base = self->fail_msg;


### PR DESCRIPTION
This should be clearer, and fixes the core issue with 810.