### PR TITLE
fixes #800 accept4 not implemented on all systems

### DIFF
--- a/src/aio/usock_posix.inc
+++ b/src/aio/usock_posix.inc
@@ -329,6 +329,11 @@ void nn_usock_accept (struct nn_usock *self, struct nn_usock *listener)
     /*  Try to accept new connection in synchronous manner. */
 #if NN_HAVE_ACCEPT4
     s = accept4 (listener->s, NULL, NULL, SOCK_CLOEXEC);
+    if ((s < 0) && (errno == ENOTSUP)) {
+        /*  Apparently some old versions of Linux have a stub for this in libc,
+            without any of the underlying kernel support. */
+        s = accept (listener->s, NULL, NULL);
+    }
 #else
     s = accept (listener->s, NULL, NULL);
 #endif

--- a/src/utils/efd_pipe.inc
+++ b/src/utils/efd_pipe.inc
@@ -38,6 +38,10 @@ int nn_efd_init (struct nn_efd *self)
 
 #if defined NN_HAVE_PIPE2
     rc = pipe2 (p, O_NONBLOCK | O_CLOEXEC);
+    if ((rc == -1) &&  (errno == ENOTSUP)) {
+        /*  Deal with unimplemented system call/libc mismatch (Linux). */
+        rc = pipe (p);
+    }
 #else
     rc = pipe (p);
 #endif


### PR DESCRIPTION
This PR adds fallbacks for both accept4 and pipe2, to use the less sophisticated (and racy) versions of those system calls.

Note that the main concern here is interaction with fork(), and if we had a proper atfork() handler, we wouldn't need to even bother with the "modern" versions.