### PR TITLE
Make the pkgconfig.in libdir variable reference the real installed library dir

### DIFF
--- a/src/pkgconfig.in
+++ b/src/pkgconfig.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${prefix}/lib
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: @CMAKE_PROJECT_NAME@
 Description: @NN_DESCRIPTION@


### PR DESCRIPTION
Currently, the `libdir` is hard-coded to be "${prefix}/lib". However depending on the system onto which the library is installed, the `CMAKE_INSTALL_LIBDIR` may not be "lib". This sets the `libdir` to be the same directory where the libraries are actually installed.

If there is a better fix for this, or if there's some reason this shouldn't go through, please let me know.

Thanks!