### PR TITLE
Fix memory leak when binding or connecting to bad URL

### DIFF
--- a/src/transports/tcp/btcp.c
+++ b/src/transports/tcp/btcp.c
@@ -118,11 +118,13 @@ int nn_btcp_create (struct nn_ep *ep)
     end = addr + strlen (addr);
     pos = strrchr (addr, ':');
     if (pos == NULL) {
+        nn_free (self);
         return -EINVAL;
     }
     ++pos;
     rc = nn_port_resolve (pos, end - pos);
     if (rc < 0) {
+        nn_free (self);
         return -EINVAL;
     }
 
@@ -134,6 +136,7 @@ int nn_btcp_create (struct nn_ep *ep)
     /*  Parse the address. */
     rc = nn_iface_resolve (addr, pos - addr - 1, ipv4only, &ss, &sslen);
     if (nn_slow (rc < 0)) {
+        nn_free (self);
         return -ENODEV;
     }
 
@@ -151,6 +154,7 @@ int nn_btcp_create (struct nn_ep *ep)
 
     rc = nn_btcp_listen (self);
     if (rc != 0) {
+        // I suspect we might need to do nn_free here.
         return rc;
     }
 

--- a/src/transports/tcp/ctcp.c
+++ b/src/transports/tcp/ctcp.c
@@ -150,10 +150,12 @@ int nn_ctcp_create (struct nn_ep *ep)
 
     /*  Parse the port. */
     if (!colon) {
+        nn_free (self);
         return -EINVAL;
     }
     rc = nn_port_resolve (colon + 1, end - colon - 1);
     if (rc < 0) {
+        nn_free (self);
         return -EINVAL;
     }
 
@@ -162,6 +164,7 @@ int nn_ctcp_create (struct nn_ep *ep)
     if (nn_dns_check_hostname (hostname, colon - hostname) < 0 &&
           nn_literal_resolve (hostname, colon - hostname, ipv4only,
           &ss, &sslen) < 0) {
+        nn_free (self);
         return -EINVAL;
     }
 
@@ -169,6 +172,7 @@ int nn_ctcp_create (struct nn_ep *ep)
     if (semicolon) {
         rc = nn_iface_resolve (addr, semicolon - addr, ipv4only, &ss, &sslen);
         if (rc < 0) {
+            nn_free (self);
             return -ENODEV;
         }
     }


### PR DESCRIPTION
In TCP, when connecting or binding to an invalid URL, you get a memory leak, because nn_close not called after editting of the URL fails.