### PR TITLE
fixes NN_MAXTTL typo in docs for nn_{get|set}sockopt

### DIFF
--- a/doc/nn_getsockopt.adoc
+++ b/doc/nn_getsockopt.adoc
@@ -112,7 +112,7 @@ _<nanomsg/nn.h>_ header defines generic socket-level options
     Socket name for error reporting and statistics. The type of the option
     is string. Default value is "N" where N is socket integer.
     *This option is experimental, see <<nn_env#,nn_env(7)>> for details*
-*NN_TTL*::
+*NN_MAXTTL*::
     Retrieves the maximum number of "hops" a message can go through before
     it is dropped.  Each time the message is received (for example via
     the <<nn_device#,nn_device(3)>> function) counts as a single hop.

--- a/doc/nn_setsockopt.adoc
+++ b/doc/nn_setsockopt.adoc
@@ -85,7 +85,7 @@ _<nanomsg/nn.h>_ header defines generic socket-level options
     Socket name for error reporting and statistics. The type of the option
     is string. Default value is "socket.N" where N is socket integer.
     *This option is experimental, see <<nn_env#,nn_env(7)>> for details*
-*NN_TTL*::
+*NN_MAXTTL*::
     Sets the maximum number of "hops" a message can go through before
     it is dropped.  Each time the message is received (for example via
     the <<nn_device#,nn_device(3)>> function) counts as a single hop.


### PR DESCRIPTION
I think this patch is all that's needed. 
I didn't add myself as an author since it's trivial changes.
I couldn't figure out how to rebuild the doc, when I follow [these](https://github.com/nanomsg/nanomsg/blob/ee99202f84f8d0e8ebd1c1722aa8a682f54919d0/doc/README) instructions, it fails like this:

```
me@nanomsg$ ./configure --enable-doc
This configure script is a convenience wrapper around
CMake.  Only a limited subset of configuration options
are supported.  For a fully featured build, use CMake.

Execute as ./configure [options]

Options supported are:

 --prefix={path}      Set installation directory prefix.
 --with-cmake={path}  Location of CMake executable.
```

I'm guesing there's a CMake option somewhere that'll output some html and manual pages?