### PR TITLE
Fix nn_getsockopt() docs: EAGAIN -> ETIMEDOUT

### DIFF
--- a/doc/nn_getsockopt.adoc
+++ b/doc/nn_getsockopt.adoc
@@ -53,12 +53,12 @@ _<nanomsg/nn.h>_ header defines generic socket-level options
     type of this option is int. Default is 1024kB.
 *NN_SNDTIMEO*::
     The timeout for send operation on the socket, in milliseconds. If message
-    cannot be sent within the specified timeout, EAGAIN error is returned.
+    cannot be sent within the specified timeout, ETIMEDOUT error is returned.
     Negative value means infinite timeout. The type of the option is int.
     Default value is -1.
 *NN_RCVTIMEO*::
     The timeout for recv operation on the socket, in milliseconds. If message
-    cannot be received within the specified timeout, EAGAIN error is returned.
+    cannot be received within the specified timeout, ETIMEDOUT error is returned.
     Negative value means infinite timeout. The type of the option is int.
     Default value is -1.
 *NN_RECONNECT_IVL*::


### PR DESCRIPTION
While the mistake in the docs for `nn_setsockopt` (#576) was fixed with f52261ca2b6b9ed5a33fec78f6afd0fb14e87574, `nn_getsockopt` was not.
The return values when using transfer timeouts are `ETIMEDOUT`, not `EAGAIN`.