### PR TITLE
Invalidates src chunkref in nn_chunkref_mv.

### DIFF
--- a/src/utils/chunkref.c
+++ b/src/utils/chunkref.c
@@ -97,6 +97,7 @@ void nn_chunkref_mv (struct nn_chunkref *dst, struct nn_chunkref *src)
 {
     memcpy (dst, src, src->u.ref [0] == 0xff ?
         (int)sizeof (struct nn_chunkref_chunk) : src->u.ref [0] + 1);
+    src->u.ref[0] = 0x00;
 }
 
 void nn_chunkref_cp (struct nn_chunkref *dst, struct nn_chunkref *src)


### PR DESCRIPTION
Assuming that the chunk hold by src exceeds NN_CHUNKREF_MAX bytes,
i.e. uref[0] == 0xff, then only a reference (resp. pointer) to the
piece of memory storing this chunk is moved to dst. Then, whenever
one calls nn_chunkref_term on one of the instances (src or dst) and
later on the other, the application will crash due to the request
of freeing an unallocated piece of memory.
For this reason, it is safer to somehow invalidate src in a call to
nn_chunkref_mv by setting its u.ref[0] to 0x00, such that a call to
nn_chunkref_term will not attempt to free memory.