### PR TITLE
Sets pipebase's data-pointer to NULL during initialization.

### DIFF
--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -58,6 +58,7 @@ void nn_pipebase_init (struct nn_pipebase *self,
     self->instate = NN_PIPEBASE_INSTATE_DEACTIVATED;
     self->outstate = NN_PIPEBASE_OUTSTATE_DEACTIVATED;
     self->sock = ep->sock;
+    self->data = NULL;
     memcpy (&self->options, &ep->options, sizeof (struct nn_ep_options));
     nn_fsm_event_init (&self->in);
     nn_fsm_event_init (&self->out);


### PR DESCRIPTION
A freshly initialized pipe(base) does not have any additional data
assigned to it. However, a receiver of a pipe might not necessarily have
the knowledge, whether or not someone else might have set the pointer to
point to additional data or not. Since the pipe is not set to NULL
during initialization of itself, the pointer is likely to contain an
arbitrary value and thus may cause later checks by the receivers of the
pipe to fail. Therefore, the data-pointer should be initialized with
value NULL in nn_pipebase_init to prevent undefined behaviour or even
crashes.