### PR TITLE
clean fix of memory leak in btcp.c when nn_bind returns EADDRINUSE

### DIFF
--- a/src/aio/fsm.c
+++ b/src/aio/fsm.c
@@ -178,6 +178,16 @@ void nn_fsm_action (struct nn_fsm *self, int type)
     nn_fsm_feed (self, NN_FSM_ACTION, type, NULL);
 }
 
+void nn_fsm_raise_from_src (struct nn_fsm *self, struct nn_fsm_event *event, 
+    int src, int type)
+{
+    event->fsm = self;
+    event->src = src;
+    event->srcptr = self->srcptr;
+    event->type = type;
+    nn_ctx_raise (self->ctx, event);
+}
+
 void nn_fsm_raise (struct nn_fsm *self, struct nn_fsm_event *event, int type)
 {
     event->fsm = self->owner;

--- a/src/aio/fsm.h
+++ b/src/aio/fsm.h
@@ -97,6 +97,10 @@ struct nn_worker *nn_fsm_choose_worker (struct nn_fsm *self);
 void nn_fsm_action (struct nn_fsm *self, int type);
 
 /*  Send event from the state machine to its owner. */
+void nn_fsm_raise_from_src (struct nn_fsm *self, struct nn_fsm_event *event, 
+    int src, int type);
+
+/*  Send event from the state machine to its owner. */
 void nn_fsm_raise (struct nn_fsm *self, struct nn_fsm_event *event, int type);
 
 


### PR DESCRIPTION
Replaces pull request 865.

Fixes memory leak that happens when nn_bind fails returning EADDRINUSE.