### PR TITLE
Add cmake variable to adjust the value of NN_MAX_SOCKETS define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ option (NN_ENABLE_GETADDRINFO_A "Enable/disable use of getaddrinfo_a in place of
 option (NN_TESTS "Build and run nanomsg tests" ON)
 option (NN_TOOLS "Build nanomsg tools" ON)
 option (NN_ENABLE_NANOCAT "Enable building nanocat utility." ${NN_TOOLS})
+set (NN_MAX_SOCKETS 512 CACHE STRING "max number of nanomsg sockets that can be created")
 
 #  Platform checks.
 
@@ -236,6 +237,8 @@ check_c_source_compiles ("
 if (NN_HAVE_GCC_ATOMIC_BUILTINS)
     add_definitions (-DNN_HAVE_GCC_ATOMIC_BUILTINS)
 endif ()
+
+add_definitions(-DNN_MAX_SOCKETS=${NN_MAX_SOCKETS})
 
 add_subdirectory (src)
 

--- a/src/core/global.c
+++ b/src/core/global.c
@@ -59,8 +59,10 @@
 #include <unistd.h>
 #endif
 
-/*  Max number of concurrent SP sockets. */
+/*  Max number of concurrent SP sockets. Configureable at build time */
+#ifndef NN_MAX_SOCKETS
 #define NN_MAX_SOCKETS 512
+#endif
 
 /*  To save some space, list of unused socket slots uses uint16_t integers to
     refer to individual sockets. If there's a need to more that 0x10000 sockets,


### PR DESCRIPTION
For https://github.com/anton-povarov/pinba2 we've stumbled on NN_MAX_SOCKETS limiting the number of internal reports to about 100, since each of them uses a few nn inproc sockets.
This is also somewhat related to #575, since we have to pre-allocate 6 sockets per report to work around the memleak.

Given that implementing automatic resizing for internal socket arrays is non-trivial, this PR makes the max number of sockets configureable at build time, via cmake variable (instead of having to fork).
