### PR TITLE
Streamhdr assertion possible due to incorrect assumption.

### DIFF
--- a/src/transports/utils/streamhdr.c
+++ b/src/transports/utils/streamhdr.c
@@ -262,7 +262,6 @@ invalidhdr:
         case NN_STREAMHDR_SRC_USOCK:
             /*  It's safe to ignore usock event when we are stopping, but there
                 is only a subset of events that are plausible. */
-            nn_assert (type == NN_USOCK_ERROR);
             return;
 
         case NN_STREAMHDR_SRC_TIMER:


### PR DESCRIPTION
This is pretty much the same situation as #894.