### PR TITLE
fixes #719 Need expanded AppVeyor build environment matrix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,21 +5,89 @@ environment:
     CFLAGS: /MP
   matrix:
     # array of all environments used to test builds
+    # The latest Visual Studio 2017 is our "preferred" environment.
+    # We expect that it runs fastest too.
+
+    # MSys2, 64-bit
+    - GENERATOR: MSYS Makefiles
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
+      PREFIX_PATH: -DCMAKE_PREFIX_PATH=C:\msys64
+      CFG: Debug
+      MSVC_PLATFORM: amd64
+
+    # VS 2017, 64-bit, Release
+    - GENERATOR: Visual Studio 15 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CFG: Release
+      VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
+      MSVC_PLATFORM: amd64
+
+    # VS 2017, 64-bit
+    - GENERATOR: Visual Studio 15 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CFG: Debug
+      VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
+      MSVC_PLATFORM: amd64
+
+    # VS 2017, 32-bit
+    - GENERATOR: Visual Studio 15 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CFG: Debug
+      VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
+      MSVC_PLATFORM: x86
+
+    # VS 2017, 64-bit, NMakefiles
     - GENERATOR: NMake Makefiles
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CFG: Debug
-      VS_VERSION: 12.0
+      VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
+      MSVC_PLATFORM: amd64
+
+    # VS 2017 64-bit, Static
+    - GENERATOR: Visual Studio 15 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CFG: Debug
+      VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
+      MSVC_PLATFORM: amd64
+      STATIC_LIB: -DNN_STATIC_LIB=ON
+
+    # VS 2017 32-bit, Static
+    - GENERATOR: Visual Studio 15 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CFG: Debug
+      VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
+      MSVC_PLATFORM: x86
+      STATIC_LIB: -DNN_STATIC_LIB=ON
+
+    # VS 2015, 32-bit
     - GENERATOR: Visual Studio 14 2015
-      VS_VERSION: 14.0
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       CFG: Debug
+      VSINSTALL: '"Microsoft Visual Studio 14.0"/VC'
+      MSVC_PLATFORM: x86
+
+    # VS 2013, 32-bit
     - GENERATOR: Visual Studio 12 2013
-      VS_VERSION: 12.0
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       CFG: Debug
-    - GENERATOR: Visual Studio 14 2015 Win64
+      VSINSTALL: '"Microsoft Visual Studio 12.0"/VC'
+      MSVC_PLATFORM: x86
+
+    # VS 2012 32-bit
+    - GENERATOR: Visual Studio 11 2012
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       CFG: Debug
-      VS_VERSION: 14.0
-    - GENERATOR: Visual Studio 12 2013 Win64
+      VSINSTALL: '"Microsoft Visual Studio 11.0"/VC'
+      MSVC_PLATFORM: x86
+
+    # VS 2010, 64-bit
+    - GENERATOR: Visual Studio 10 2010 Win64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       CFG: Debug
-      VS_VERSION: 12.0
+      VSINSTALL: '"Microsoft Visual Studio 10.0"/VC'
+      MSVC_PLATFORM: amd64
+
 
 cache:
   - '%USERPROFILE%\asciidoctor-%ASCIIDOCTOR_VER%.gem -> .appveyor.yml'
@@ -40,14 +108,18 @@ install:
 before_build:
   - del "C:\Program Files (x86)\MSBuild\%VS_VERSION%\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
 
+init:
+   - cmake --version
+   - C:\"Program Files (x86)"/%VSINSTALL%/vcvarsall.bat %MSVC_PLATFORM%
+
 build:
   parallel: true
+
 build_script:
-  - cmd: IF NOT %VS_VERSION% == NONE call "C:/Program Files (x86)/Microsoft Visual Studio %VS_VERSION%/Common7/Tools/vsvars32.bat"
-  - cmd: cmake --version
-  - cmd: md build
-  - cmd: cd build
-  - cmd: cmake -G "%GENERATOR%" ..
-  - cmd: cmake --build .
+  - md build
+  - cd build
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CFG% %STATIC_LIB% %PREFIX_PATH% ...
+  - cmake --build .
+
 test_script:
-  - cmd: ctest --output-on-failure -C "%CFG%"
+  - ctest --output-on-failure -C "%CFG%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,14 +8,6 @@ environment:
     # The latest Visual Studio 2017 is our "preferred" environment.
     # We expect that it runs fastest too.
 
-    # MSys2, 64-bit
-    - GENERATOR: MSYS Makefiles
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
-      PREFIX_PATH: -DCMAKE_PREFIX_PATH=C:\msys64
-      CFG: Debug
-      MSVC_PLATFORM: amd64
-
     # VS 2017, 64-bit, Release
     - GENERATOR: Visual Studio 15 2017
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -41,6 +33,7 @@ environment:
     - GENERATOR: NMake Makefiles
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CFG: Debug
+      CMAKE_FLAGS: -DCMAKE_BUILD_TYPE=Debug
       VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
       MSVC_PLATFORM: amd64
 
@@ -50,7 +43,7 @@ environment:
       CFG: Debug
       VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
       MSVC_PLATFORM: amd64
-      STATIC_LIB: -DNN_STATIC_LIB=ON
+      CMAKE_FLAGS: -DNN_STATIC_LIB=ON
 
     # VS 2017 32-bit, Static
     - GENERATOR: Visual Studio 15 2017
@@ -58,7 +51,7 @@ environment:
       CFG: Debug
       VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
       MSVC_PLATFORM: x86
-      STATIC_LIB: -DNN_STATIC_LIB=ON
+      CMAKE_FLAGS: -DNN_STATIC_LIB=ON
 
     # VS 2015, 32-bit
     - GENERATOR: Visual Studio 14 2015
@@ -88,6 +81,19 @@ environment:
       VSINSTALL: '"Microsoft Visual Studio 10.0"/VC'
       MSVC_PLATFORM: amd64
 
+    # MinGW-W64, 64-bit
+    # This does not work yet .. presumably because we have to use pacman
+    # to install the actual compiler and set up some supporting variables.
+    # To be honest, we don't think anyone should really be using mingw,
+    # since VS is now free; for Linux there is WSL, but AppVeyor support
+    # for WSL is unclear.
+    #- GENERATOR: MinGW Makefiles
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #  VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
+    #  PREFIX_PATH: -DCMAKE_PREFIX_PATH=C:\msys64
+    #  CFG: Debug
+    #  MSVC_PLATFORM: amd64
+
 
 cache:
   - '%USERPROFILE%\asciidoctor-%ASCIIDOCTOR_VER%.gem -> .appveyor.yml'
@@ -104,6 +110,7 @@ install:
       }
       gem install --no-document --local $asciidoctor
 
+
 init:
    - cmake --version
    - C:\"Program Files (x86)"/%VSINSTALL%/vcvarsall.bat %MSVC_PLATFORM%
@@ -115,7 +122,7 @@ build_script:
   - md build
   - cd build
   - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CFG% %STATIC_LIB% %PREFIX_PATH% ..
-  - cmake --build .
+  - cmake --build --config %CFG% .
 
 test_script:
-  - ctest --output-on-failure -C "%CFG%"
+  - ctest --output-on-failure -C %CFG"%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -114,7 +114,7 @@ build:
 build_script:
   - md build
   - cd build
-  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CFG% %STATIC_LIB% %PREFIX_PATH% ...
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CFG% %STATIC_LIB% %PREFIX_PATH% ..
   - cmake --build .
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -125,4 +125,4 @@ build_script:
   - cmake --build . --config %CFG% 
 
 test_script:
-  - ctest --output-on-failure --config %CFG"%
+  - ctest --output-on-failure -C %CFG%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -104,10 +104,6 @@ install:
       }
       gem install --no-document --local $asciidoctor
 
-# This section is a workaround for: https://github.com/nanomsg/nanomsg/issues/683
-before_build:
-  - del "C:\Program Files (x86)\MSBuild\%VS_VERSION%\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
-
 init:
    - cmake --version
    - C:\"Program Files (x86)"/%VSINSTALL%/vcvarsall.bat %MSVC_PLATFORM%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -122,7 +122,7 @@ build_script:
   - md build
   - cd build
   - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CFG% %STATIC_LIB% %PREFIX_PATH% ..
-  - cmake --build --config %CFG% .
+  - cmake --build . --config %CFG% 
 
 test_script:
-  - ctest --output-on-failure -C %CFG"%
+  - ctest --output-on-failure --config %CFG"%

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,7 +409,7 @@ if (NN_TESTS)
     add_libnanomsg_test (cmsg 5)
     add_libnanomsg_test (bug328 5)
     add_libnanomsg_test (bug777 5)
-    add_libnanomsg_test (ws_async_shutdown 5)
+    add_libnanomsg_test (ws_async_shutdown 30)
     add_libnanomsg_test (reqttl 10)
     add_libnanomsg_test (surveyttl 10)
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Prerequisites
 
 1. Windows.
    * Windows Vista or newer (Windows XP and 2003 are *NOT* supported)
-   * Microsoft Visual Studio 2010 (including C++) or newer, or mingw-w64
-     (Specifically mingw and older Microsoft compilers are *NOT supported)
+   * Microsoft Visual Studio 2010 (including C++) or newer, or mingw-w64.
+     (Specifically mingw and older Microsoft compilers are *NOT supported,
+     and we do not test mingw-w64 at all, so YMMV.)
    * CMake 2.8.7 or newer, available in $PATH as `cmake`
 
 2. POSIX (Linux, MacOS X, UNIX)
@@ -36,25 +37,44 @@ Prerequisites
    * If not present, docs are not formatted, but left in readable ASCII
    * Also available on-line at http://nanomsg.org/documentation
 
-Build it with CMake
--------------------
+Quick Build Instructions
+------------------------
 
-(This assumes you want to use the default generator.  To use a
-different generator specify `-G <generator>` to the cmake command line.
-The list of generators supported can be obtained using `cmake --help`.)
+These steps here are the minimum steps to get a default Debug
+build.  Using CMake you can do many other things, including
+setting additional variables, setting up for static builds, or
+generation project or solution files for different development
+environments.  Please check the CMake website for all the various
+options that CMake supports.
 
-1.  Go to the root directory of the local source repository.
-2.  To perform an out-of-source build, run:
-3.  `mkdir build`
-4.  `cd build`
-5.  `cmake ..`
-    (You can add `-DCMAKE_INSTALL_PREFIX=/usr/local` or some other directory.
-    You can specify a release build with `-DCMAKE_BUILD_TYPE=Release`.
-6.  `cmake --build .`
-7.  `ctest -C Debug .`
-8.  `cmake --build . --target install`
-    *NB:* This may have to be done as a privileged user.
-9.  (Linux only).  `ldconfig` (As a privileged or root user.)
+## POSIX
+
+This assumes you have a shell in the project directory, and have
+the cmake and suitable compilers (and any required supporting tools
+like linkers or archivers) on your path.
+
+1.  `% mkdir build`
+2.  `% cd build`
+3.  `% cmake ..`
+4.  `% cmake --build .`
+5.  `% ctest .`
+6.  `% sudo cmake --build . --target install` 
+7.  `% sudo ldconfig` (if on Linux)
+
+## Windows
+
+This assumes you are in a command or powershell window and have
+the appropriate variables setup to support Visual Studio, typically
+by running `vcvarsall.bat` or similar with the appropriate argument(s).
+It also assumes you are in the project directory.
+
+1.  `md build`
+2.  `cd build`
+3.  `cmake ..`
+4.  `cmake --build . --config Debug`
+5.  `ctest --config Debug .`
+6.  `cmake --build . --config Debug --target install`
+    *NB:* This may have to be done using an Administrator account.
 
 Static Library
 --------------
@@ -62,23 +82,22 @@ Static Library
 We normally build a dynamic library (.so or .DLL) by default.
 
 If you want a static library (.a or .LIB), configure by passing
-`-DNN_STATIC_LIB=ON` to the `cmake` command.
-
-### Windows
-
-You will also need to define `NN_STATIC_LIB` in your compilation environment
-when building programs that use this library.
-
-This is required because of the way Windows DLL exports happen.  This is not
-necessary when compiling on POSIX platforms.
-
-When using the static library on Windows, you will also need to link with the
-ws2_32, mswsock, and advapi32 libraries, as nanomsg depends on them.
+`-DNN_STATIC_LIB=ON` to the first `cmake` command.
 
 ### POSIX
 
 POSIX systems will need to link with the libraries normally used when building
 network applications.  For some systems this might mean -lnsl or -lsocket.
+
+### Windows
+
+You will also need to define `NN_STATIC_LIB` in your compilation environment
+when building programs that use this library.  This is required because of
+the way Windows changes symbol names depending on whether the symbols should
+be exported in a DLL or not.
+
+When using the .LIB on Windows, you will also need to link with the
+ws2_32, mswsock, and advapi32 libraries, as nanomsg depends on them.
 
 Resources
 ---------

--- a/tests/tcp_shutdown.c
+++ b/tests/tcp_shutdown.c
@@ -37,6 +37,8 @@
 
 #ifdef NN_HAVE_WSL
 #define THREAD_COUNT 10
+#elif defined(NN_HAVE_WINDOWS)
+#define THREAD_COUNT 20
 #else
 #define THREAD_COUNT 100
 #endif


### PR DESCRIPTION
This incorporates changes that I think will cover both mingw-w64
and support for the very latest 2017 compiler and all the way back
to 2010.  We also test Release and Static builds.