### PR TITLE
memleak: fixed memory leak when socket allocated, but init returns failure.

### DIFF
--- a/src/core/global.c
+++ b/src/core/global.c
@@ -403,7 +403,7 @@ struct nn_cmsghdr *nn_cmsg_nxthdr_ (const struct nn_msghdr *mhdr,
     if (headsz + NN_CMSG_SPACE (0) > sz ||
           headsz + NN_CMSG_ALIGN_ (next->cmsg_len) > sz)
         return NULL;
-    
+
     /*  Success. */
     return next;
 }
@@ -439,8 +439,10 @@ int nn_global_create_socket (int domain, int protocol)
             if ((sock = nn_alloc (sizeof (struct nn_sock), "sock")) == NULL)
                 return -ENOMEM;
             rc = nn_sock_init (sock, socktype, s);
-            if (rc < 0)
+            if (rc < 0) {
+                nn_free (sock);
                 return rc;
+            }
 
             /*  Adjust the global socket table. */
             self.socks [s] = sock;


### PR DESCRIPTION
Exposed by emfile test.

How to reproduce:
Build nanomsg with memory sanitizer 
`CC=clang CXX=clang++ cmake .. -DCMAKE_C_FLAGS="-g -fsanitize=address -fno-omit-frame-pointer -O1"`

Run emfile test
> $ ./emfile 

Report will be

> =================================================================
> ==5379==ERROR: LeakSanitizer: detected memory leaks
> 
> Direct leak of 592 byte(s) in 1 object(s) allocated from:
>     #0 0x4f33b6 in malloc /home/snikulov/work/build/llvm/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:67
>     #1 0x7f70cbaa4577 in nn_global_create_socket /home/snikulov/work/github/NANO/dev/nanomsg/src/core/global.c:439:25
>     #2 0x7f70cbaa4192 in nn_socket /home/snikulov/work/github/NANO/dev/nanomsg/src/core/global.c:480:10
>     #3 0x526b4e in main /home/snikulov/work/github/NANO/dev/nanomsg/tests/emfile.c:38:21
>     #4 0x7f70ca77ac04 in __libc_start_main /usr/src/debug/glibc-2.17-c758a686/csu/../csu/libc-start.c:274
> 
> SUMMARY: AddressSanitizer: 592 byte(s) leaked in 1 allocation(s).
> 
> 