### PR TITLE
Enable version handling in exported CMake package

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Bruce Mitchener <bruce.mitchener@gmail.com>
 Bruno Bigras <bigras.bruno@gmail.com>
 Chip Salzenberg <chip@pobox.com>
 David Beck <dbeck@beckground.hu>
+Dennis Klein <d.klein@gsi.de>
 Dirkjan Ochtman <dirkjan@ochtman.nl>
 Dong Fang <yp.fangdong@gmail.com>
 Drew Crawford <drew@sealedabstract.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 #   IN THE SOFTWARE.
 #
 
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 2.8.12)
 
 project (nanomsg C)
 include (CheckFunctionExists)

--- a/cmake/nanomsg-config.cmake.in
+++ b/cmake/nanomsg-config.cmake.in
@@ -1,0 +1,34 @@
+#
+#   Copyright (c) 2018 Dennis Klein <d.klein@gsi.de>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom
+#   the Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+#   IN THE SOFTWARE.
+#
+
+@PACKAGE_INIT@
+
+### General variables for project discovery/inspection
+set_and_check(@PROJECT_NAME@_INSTALL_PREFIX @PACKAGE_CMAKE_INSTALL_PREFIX@)
+set_and_check(@PROJECT_NAME@_BINDIR @PACKAGE_CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@)
+set_and_check(@PROJECT_NAME@_INCDIR @PACKAGE_CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@)
+set_and_check(@PROJECT_NAME@_LIBDIR @PACKAGE_CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@)
+
+### Import targets
+include(@PACKAGE_CMAKE_INSTALL_PREFIX@/@PACKAGE_INSTALL_DESTINATION@/@PROJECT_NAME@-target.cmake)
+
+check_required_components(@PROJECT_NAME@)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@
 #   Copyright (c) 2013 GoPivotal, Inc.  All rights reserved.
 #   Copyright (c) 2015-2016 Jack R. Dunaway. All rights reserved.
 #   Copyright 2016 Garrett D'Amore <garrett@damore.org>
+#   Copyright (c) 2018 Dennis Klein <d.klein@gsi.de>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
 #   of this software and associated documentation files (the "Software"),
@@ -377,4 +378,28 @@ install (TARGETS ${PROJECT_NAME}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
-install (EXPORT ${PROJECT_NAME}-target DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME} FILE ${PROJECT_NAME}-config.cmake)
+
+# Generate and install CMake package
+include(CMakePackageConfigHelpers)
+set(PACKAGE_INSTALL_DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${NN_PACKAGE_VERSION}
+)
+install(EXPORT ${PROJECT_NAME}-target
+    DESTINATION ${PACKAGE_INSTALL_DESTINATION}
+)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    VERSION ${NN_PACKAGE_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+configure_package_config_file(
+    ${CMAKE_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION ${PACKAGE_INSTALL_DESTINATION}
+    PATH_VARS CMAKE_INSTALL_PREFIX
+)
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    DESTINATION ${PACKAGE_INSTALL_DESTINATION}
+)


### PR DESCRIPTION
This implements the version constraint signature of the `find_package` CMake command, e.g. one can find a minimum version or a specific version:

```cmake
find_package(nanomsg 1.1.4 [EXACT])
```

---

The bump of the minimum required CMake version might not be necessary, but I only know for sure, it will work with CMake `2.8.12+`. It might work even earlier, but the upstream git repo does not reflect any earlier versions. If anyone knows better, would be great.
