### PR TITLE
Fix code which breaks strict aliasing rule in C language

### DIFF
--- a/src/aio/usock_posix.inc
+++ b/src/aio/usock_posix.inc
@@ -1085,6 +1085,7 @@ static int nn_usock_recv_raw (struct nn_usock *self, void *buf, size_t *len)
 #if defined NN_HAVE_MSG_CONTROL
     struct cmsghdr *cmsg;
 #endif
+    int fd;
 
     /*  If batch buffer doesn't exist, allocate it. The point of delayed
         deallocation to allow non-receiving sockets, such as TCP listening
@@ -1152,13 +1153,16 @@ static int nn_usock_recv_raw (struct nn_usock *self, void *buf, size_t *len)
 #if defined NN_HAVE_MSG_CONTROL
         cmsg = CMSG_FIRSTHDR (&hdr);
         while (cmsg) {
-            if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
+            if (cmsg->cmsg_level == SOL_SOCKET &&
+                  cmsg->cmsg_type == SCM_RIGHTS) {
                 if (self->in.pfd) {
-                    *self->in.pfd = *((int*) CMSG_DATA (cmsg));
+                    memcpy (self->in.pfd, CMSG_DATA (cmsg),
+                        sizeof (*self->in.pfd));
                     self->in.pfd = NULL;
                 }
                 else {
-                    nn_closefd (*((int*) CMSG_DATA (cmsg)));
+                    memcpy (&fd, CMSG_DATA (cmsg), sizeof (fd));
+                    nn_closefd (fd);
                 }
                 break;
             }
@@ -1168,11 +1172,13 @@ static int nn_usock_recv_raw (struct nn_usock *self, void *buf, size_t *len)
         if (hdr.msg_accrightslen > 0) {
             nn_assert (hdr.msg_accrightslen == sizeof (int));
             if (self->in.pfd) {
-                *self->in.pfd = *((int*) hdr.msg_accrights);
+                memcpy (self->in.pfd, hdr.msg_accrights,
+                    sizeof (*self->in.pfd));
                 self->in.pfd = NULL;
             }
             else {
-                nn_closefd (*((int*) hdr.msg_accrights));
+                memcpy (&fd, hdr.msg_accrights, sizeof (fd));
+                nn_closefd (fd);
             }
         }
 #endif


### PR DESCRIPTION
Use memcpy() instead of dereferencing a type-punned pointer. This avoids warnings from the compiler, which indicate it may optimize the code in a way that results in unexpected behavior.