### PR TITLE
Update list of Python bindings.

### DIFF
--- a/_adoc/documentation.adoc
+++ b/_adoc/documentation.adoc
@@ -135,18 +135,15 @@ layout: default
 |https://github.com/aw/picolisp-nanomsg[picolisp-nanomsg] FFI bindings
 |
 
-.4+<|Python
+.3+<|Python
 |https://github.com/tonysimpson/nanomsg-python[nanomsg-python]
-|(recommended)
-
-|https://github.com/sdiehl/pynanomsg[pynanomsg]
 |
 
 |https://github.com/djc/nnpy[nnpy]
 |
 
-|https://github.com/mark-r-stevens/pynng[pynng]
-|(NNG binding, work in progress)
+|https://github.com/codypiersall/pynng[pynng]
+|NNG binding. https://pynng.readthedocs.io[Docs here].
 
 |R
 |https://github.com/mhowlett/rnanomsg[rnanomsg]

--- a/documentation.html
+++ b/documentation.html
@@ -613,12 +613,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" rowspan="4"><p class="tableblock">Python</p></td>
+<td class="tableblock halign-left valign-top" rowspan="3"><p class="tableblock">Python</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://github.com/tonysimpson/nanomsg-python">nanomsg-python</a></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">(recommended)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://github.com/sdiehl/pynanomsg">pynanomsg</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
@@ -626,8 +622,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://github.com/mark-r-stevens/pynng">pynng</a></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">(NNG binding, work in progress)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://github.com/codypiersall/pynng">pynng</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NNG binding. <a href="https://pynng.readthedocs.io">Docs here</a>.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">R</p></td>
@@ -673,7 +669,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2018-11-02 20:40:06 UTC
+Last updated 2018-11-03 16:23:44 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nanocat.html
+++ b/v1.1.5/nanocat.html
@@ -739,7 +739,7 @@ resending the requests is actually work:</p>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nanomsg.html
+++ b/v1.1.5/nanomsg.html
@@ -626,7 +626,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_allocmsg.html
+++ b/v1.1.5/nn_allocmsg.html
@@ -532,7 +532,7 @@ nn_send (s, &amp;buf, NN_MSG, 0);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_bind.html
+++ b/v1.1.5/nn_bind.html
@@ -585,7 +585,7 @@ eid2 = nn_bind (s, "tcp://127.0.0.1:5560");</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_bus.html
+++ b/v1.1.5/nn_bus.html
@@ -524,7 +524,7 @@ socket.</p>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_close.html
+++ b/v1.1.5/nn_close.html
@@ -522,7 +522,7 @@ assert (rc == 0);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_cmsg.html
+++ b/v1.1.5/nn_cmsg.html
@@ -551,7 +551,7 @@ while (hdr != NULL) {
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_connect.html
+++ b/v1.1.5/nn_connect.html
@@ -579,7 +579,7 @@ eid2 = nn_connect (s, "tcp://server001:5560");</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_device.html
+++ b/v1.1.5/nn_device.html
@@ -537,7 +537,7 @@ nn_device (s1, s2);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_env.html
+++ b/v1.1.5/nn_env.html
@@ -503,7 +503,7 @@ after 1.0 release).</p>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_errno.html
+++ b/v1.1.5/nn_errno.html
@@ -516,7 +516,7 @@ if (rc &lt; 0)
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_freemsg.html
+++ b/v1.1.5/nn_freemsg.html
@@ -519,7 +519,7 @@ nn_freemsg (buf);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_get_statistic.html
+++ b/v1.1.5/nn_get_statistic.html
@@ -603,7 +603,7 @@ if (val == 0)
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_getsockopt.html
+++ b/v1.1.5/nn_getsockopt.html
@@ -663,7 +663,7 @@ nn_getsockopt (s, NN_SOL_SOCKET, NN_LINGER, &amp;linger, &amp;sz);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_inproc.html
+++ b/v1.1.5/nn_inproc.html
@@ -511,7 +511,7 @@ nn_connect (s2, "inproc://test);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_ipc.html
+++ b/v1.1.5/nn_ipc.html
@@ -506,7 +506,7 @@ nn_connect (s2, "ipc:///tmp/test.ipc");</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_pair.html
+++ b/v1.1.5/nn_pair.html
@@ -514,7 +514,7 @@ message.</p>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_pipeline.html
+++ b/v1.1.5/nn_pipeline.html
@@ -506,7 +506,7 @@ operation is not implemented on this socket type.</p>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_poll.html
+++ b/v1.1.5/nn_poll.html
@@ -592,7 +592,7 @@ if (pfd [0].revents &amp; NN_POLLIN) {
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_pubsub.html
+++ b/v1.1.5/nn_pubsub.html
@@ -578,7 +578,7 @@ nbytes = nn_recv(sub, &amp;buf, NN_MSG, 0);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_reallocmsg.html
+++ b/v1.1.5/nn_reallocmsg.html
@@ -519,7 +519,7 @@ nn_freemsg (newbuf);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_recv.html
+++ b/v1.1.5/nn_recv.html
@@ -605,7 +605,7 @@ it is a zero-copy operation.</p>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_recvmsg.html
+++ b/v1.1.5/nn_recvmsg.html
@@ -608,7 +608,7 @@ nn_recvmsg (s, &amp;hdr, 0);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_reqrep.html
+++ b/v1.1.5/nn_reqrep.html
@@ -533,7 +533,7 @@ resent. The type of this option is int. Default value is 60000 (1 minute).</p>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_send.html
+++ b/v1.1.5/nn_send.html
@@ -586,7 +586,7 @@ assert (nbytes == 3);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_sendmsg.html
+++ b/v1.1.5/nn_sendmsg.html
@@ -650,7 +650,7 @@ nn_sendmsg (s, &amp;hdr, 0);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_setsockopt.html
+++ b/v1.1.5/nn_setsockopt.html
@@ -638,7 +638,7 @@ nn_setsockopt (s, NN_SUB, NN_SUB_SUBSCRIBE, "ABC", 3);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_shutdown.html
+++ b/v1.1.5/nn_shutdown.html
@@ -531,7 +531,7 @@ nn_shutdown (s, eid);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_socket.html
+++ b/v1.1.5/nn_socket.html
@@ -571,7 +571,7 @@ assert (s &gt;= 0);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_strerror.html
+++ b/v1.1.5/nn_strerror.html
@@ -509,7 +509,7 @@ if (rc &lt; 0)
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_survey.html
+++ b/v1.1.5/nn_survey.html
@@ -516,7 +516,7 @@ in milliseconds. Option type is int. Default value is 1000 (1 second).</p>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_symbol.html
+++ b/v1.1.5/nn_symbol.html
@@ -540,7 +540,7 @@ for (i = 0; ; ++i) {
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_symbol_info.html
+++ b/v1.1.5/nn_symbol_info.html
@@ -679,7 +679,7 @@ for (i = 0; ; ++i) {
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_tcp.html
+++ b/v1.1.5/nn_tcp.html
@@ -560,7 +560,7 @@ nn_connect (s2, "tcp://myserver:5555");</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_term.html
+++ b/v1.1.5/nn_term.html
@@ -511,7 +511,7 @@ assert (rc == -1 &amp;&amp; errno == EBADF);</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>

--- a/v1.1.5/nn_ws.html
+++ b/v1.1.5/nn_ws.html
@@ -573,7 +573,7 @@ nn_connect (s2, "ws://myserver:5555");</pre>
 <div id="footer">
 <div id="footer-text">
 nanomsg 1.1.5<br>
-Last updated 2018-12-04 04:03:24 UTC
+Last updated 2018-12-04 04:48:58 UTC
 </div>
 </div>
 </body>


### PR DESCRIPTION
- No longer recommend nanomsg-python.  It is unmaintained.
- Remove pynanomsg from the list.  Its source repository has been
  archived.
- Point pynng to https://github.com/codypiersall/pynng.