### PR TITLE
Fix: nn_poll exits immediately when asked to wait indefinitely

### DIFF
--- a/src/core/poll.c
+++ b/src/core/poll.c
@@ -66,7 +66,7 @@ int nn_poll (struct nn_pollfd *fds, int nfds, int timeout)
     tv.tv_sec = timeout / 1000;
     tv.tv_usec = timeout % 1000 * 1000;
     if (nn_fast (nfds)) {
-        rc = select (-1, &fdset, NULL, NULL, &tv);
+        rc = select (-1, &fdset, NULL, NULL, timeout == -1 ? NULL : &tv);
         if (nn_slow (rc == 0))
             return 0;
         if (nn_slow (rc == SOCKET_ERROR)) {


### PR DESCRIPTION
Calling `nn_poll` with `timeout` set to -1 should result in infinite wait howver on Windows it was exiting immediately with return code suggesting timeout. 

To wait without timeout `select` expects `null` as timeout.  However `nn_poll` was always passing valid `timeval` structure.