### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ It also assumes you are in the project directory.
 6.  `cmake --build . --config Debug --target install`
     *NB:* This may have to be done using an Administrator account.
 
+Alternatively, you can build and install nanomsg using [vcpkg](https://github.com/microsoft/vcpkg/) dependency manager:
+
+1.  `git clone https://github.com/Microsoft/vcpkg.git`
+2.  `cd vcpkg`
+3.  `./bootstrap-vcpkg.bat`
+4.  `./vcpkg integrate install`
+5.  `./vcpkg install nanomsg`
+
+The nanomsg port in vcpkg is kept up to date by microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Static Library
 --------------
 


### PR DESCRIPTION
nanomsg is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build nanomsg, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for nanomsg and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.
