### PR TITLE
docs: fix simple typo, attemps -> attempts

### DIFF
--- a/src/transports/ipc/cipc.c
+++ b/src/transports/ipc/cipc.c
@@ -315,7 +315,7 @@ static void nn_cipc_handler (struct nn_fsm *self, int src, int type,
 /******************************************************************************/
 /*  WAITING state.                                                            */
 /*  Waiting before re-connection is attempted. This way we won't overload     */
-/*  the system by continuous re-connection attempts.                           */
+/*  the system by continuous re-connection attempts.                          */
 /******************************************************************************/
     case NN_CIPC_STATE_WAITING:
         switch (src) {

--- a/src/transports/ipc/cipc.c
+++ b/src/transports/ipc/cipc.c
@@ -315,7 +315,7 @@ static void nn_cipc_handler (struct nn_fsm *self, int src, int type,
 /******************************************************************************/
 /*  WAITING state.                                                            */
 /*  Waiting before re-connection is attempted. This way we won't overload     */
-/*  the system by continuous re-connection attemps.                           */
+/*  the system by continuous re-connection attempts.                           */
 /******************************************************************************/
     case NN_CIPC_STATE_WAITING:
         switch (src) {

--- a/src/transports/tcp/btcp.c
+++ b/src/transports/tcp/btcp.c
@@ -48,7 +48,7 @@
 #endif
 
 /*  The backlog is set relatively high so that there are not too many failed
-    connection attemps during re-connection storms. */
+    connection attempts during re-connection storms. */
 #define NN_BTCP_BACKLOG 100
 
 #define NN_BTCP_STATE_IDLE 1

--- a/src/transports/tcp/ctcp.c
+++ b/src/transports/tcp/ctcp.c
@@ -439,7 +439,7 @@ static void nn_ctcp_handler (struct nn_fsm *self, int src, int type,
 /******************************************************************************/
 /*  WAITING state.                                                            */
 /*  Waiting before re-connection is attempted. This way we won't overload     */
-/*  the system by continuous re-connection attempts.                           */
+/*  the system by continuous re-connection attempts.                          */
 /******************************************************************************/
     case NN_CTCP_STATE_WAITING:
         switch (src) {

--- a/src/transports/tcp/ctcp.c
+++ b/src/transports/tcp/ctcp.c
@@ -439,7 +439,7 @@ static void nn_ctcp_handler (struct nn_fsm *self, int src, int type,
 /******************************************************************************/
 /*  WAITING state.                                                            */
 /*  Waiting before re-connection is attempted. This way we won't overload     */
-/*  the system by continuous re-connection attemps.                           */
+/*  the system by continuous re-connection attempts.                           */
 /******************************************************************************/
     case NN_CTCP_STATE_WAITING:
         switch (src) {

--- a/src/transports/ws/bws.c
+++ b/src/transports/ws/bws.c
@@ -47,7 +47,7 @@
 #endif
 
 /*  The backlog is set relatively high so that there are not too many failed
-    connection attemps during re-connection storms. */
+    connection attempts during re-connection storms. */
 #define NN_BWS_BACKLOG 100
 
 #define NN_BWS_STATE_IDLE 1

--- a/src/transports/ws/cws.c
+++ b/src/transports/ws/cws.c
@@ -519,7 +519,7 @@ static void nn_cws_handler (struct nn_fsm *self, int src, int type,
 /******************************************************************************/
 /*  WAITING state.                                                            */
 /*  Waiting before re-connection is attempted. This way we won't overload     */
-/*  the system by continuous re-connection attempts.                           */
+/*  the system by continuous re-connection attempts.                          */
 /******************************************************************************/
     case NN_CWS_STATE_WAITING:
         switch (src) {

--- a/src/transports/ws/cws.c
+++ b/src/transports/ws/cws.c
@@ -519,7 +519,7 @@ static void nn_cws_handler (struct nn_fsm *self, int src, int type,
 /******************************************************************************/
 /*  WAITING state.                                                            */
 /*  Waiting before re-connection is attempted. This way we won't overload     */
-/*  the system by continuous re-connection attemps.                           */
+/*  the system by continuous re-connection attempts.                           */
 /******************************************************************************/
     case NN_CWS_STATE_WAITING:
         switch (src) {


### PR DESCRIPTION
There is a small typo in src/transports/ipc/cipc.c, src/transports/tcp/btcp.c, src/transports/tcp/ctcp.c, src/transports/ws/bws.c, src/transports/ws/cws.c.

Should read `attempts` rather than `attemps`.

