### PR TITLE
Fix misspelled words found by codespell tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,7 @@ if (NN_ENABLE_DOC)
     endif ()
 endif ()
 
-# Build the documenation
+# Build the documentation
 if (NN_ENABLE_DOC)
 
     set (NN_DOCDIR ${CMAKE_CURRENT_SOURCE_DIR}/doc)

--- a/rfc/sp-surveyor-01.txt
+++ b/rfc/sp-surveyor-01.txt
@@ -453,7 +453,7 @@ Internet-Draft            Surveor/Respondent SP               March 2015
 5.2.  RESPONDENT endpoint
 
    RESPONDENT endpoints are used to receive surveys from the clients and
-   send resopnses back to the clients.
+   send responses back to the clients.
 
    First of all, each RESPONDENT socket is responsible for assigning
    unique 31-bit channel IDs to the individual associated channels.
@@ -603,7 +603,7 @@ Internet-Draft            Surveor/Respondent SP               March 2015
    algorithm above.
 
    Finally, when the timeout for a survey expires, then the survey must
-   be canceled in a manner similar to user-initiated cancelation.  That
+   be canceled in a manner similar to user-initiated cancellation.  That
    is, the stored copy of the survey must be deleted, the timer removed,
    and any further responses received with the same survey ID are
    subsequently discarded.

--- a/rfc/sp-surveyor-01.xml
+++ b/rfc/sp-surveyor-01.xml
@@ -406,7 +406,7 @@
       <section title = "RESPONDENT endpoint">
 
         <t>RESPONDENT endpoints are used to receive surveys from the clients
-	   and send resopnses back to the clients.</t>
+	   and send responses back to the clients.</t>
 
         <t>First of all, each RESPONDENT socket is responsible for assigning
 	   unique 31-bit channel IDs to the individual associated channels.</t>
@@ -545,7 +545,7 @@
            algorithm above.</t>
 
 	<t>Finally, when the timeout for a survey expires, then the survey
-	   must be canceled in a manner similar to user-initiated cancelation.
+	   must be canceled in a manner similar to user-initiated cancellation.
 	   That is, the stored copy of the survey must be deleted, the timer
 	   removed, and any further responses received with the same survey ID
 	   are subsequently discarded.</t>

--- a/rfc/sp-udp-mapping-01.txt
+++ b/rfc/sp-udp-mapping-01.txt
@@ -139,7 +139,7 @@ Internet-Draft             UDP mapping for SPs              October 2016
    op codes can be assigned, obviating the need for an explicit version
    field.
 
-   These operation codes are used in the mangement of logical
+   These operation codes are used in the management of logical
    connections, and are described in more detail in the Logical
    Connections section below.
 
@@ -206,7 +206,7 @@ Internet-Draft             UDP mapping for SPs              October 2016
 5.1.  Connection roles
 
    As with other transports like TCP, we intentionally create the notion
-   of a connection initiator, and a connection accepter.  The initator
+   of a connection initiator, and a connection accepter.  The initiator
    is always the party who initiates the connection, and is the party
    responsible for sending CREQ messages.  The accepter is the party
    that receives the CREQ messages, and replies with CACK (or possibly
@@ -232,7 +232,7 @@ Internet-Draft             UDP mapping for SPs              October 2016
    data for each session.  In order to prevent a stale session from
    consuming these resources forever, and in order to keep any
    intervening state active (e.g. NAT rules), a CACK message may be sent
-   at any time by the initator.
+   at any time by the initiator.
 
    In the event of an error, the accepter MAY reply with an DISC
    message.  Otherwise it MUST reply with a CREQ message.

--- a/rfc/sp-udp-mapping-01.xml
+++ b/rfc/sp-udp-mapping-01.xml
@@ -117,7 +117,7 @@
          additional op codes can be assigned, obviating the need for an
          explicit version field.</t>
 
-      <t>These operation codes are used in the mangement of logical connections,
+      <t>These operation codes are used in the management of logical connections,
          and are described in more detail in the Logical Connections section
          below.</t>
 
@@ -185,7 +185,7 @@
 
            <t>As with other transports like TCP, we intentionally create the
            notion of a connection initiator, and a connection accepter.
-           The initator is always the party who initiates the connection,
+           The initiator is always the party who initiates the connection,
            and is the party responsible for sending CREQ messages. The
            accepter is the party that receives the CREQ messages, and
            replies with CACK (or possibly DISC).</t>
@@ -201,7 +201,7 @@
         store data for each session.  In order to prevent a stale session
         from consuming these resources forever, and in order to keep
         any intervening state active (e.g. NAT rules), a CACK message may be
-        sent at any time by the initator.</t>
+        sent at any time by the initiator.</t>
 
         <t>In the event of an error, the accepter MAY reply with an
         DISC message.  Otherwise it MUST reply with a CREQ message.</t>

--- a/src/aio/fsm.h
+++ b/src/aio/fsm.h
@@ -87,8 +87,8 @@ void nn_fsm_stop (struct nn_fsm *self);
 void nn_fsm_stopped (struct nn_fsm *self, int type);
 void nn_fsm_stopped_noevent (struct nn_fsm *self);
 
-/*  Replaces current owner of the fsm by the owner speicified by 'owner'
-    parameter. The parameter will hold the old owner afrer the call. */
+/*  Replaces current owner of the fsm by the owner specified by 'owner'
+    parameter. The parameter will hold the old owner after the call. */
 void nn_fsm_swap_owner (struct nn_fsm *self, struct nn_fsm_owner *owner);
 
 struct nn_worker *nn_fsm_choose_worker (struct nn_fsm *self);
@@ -114,7 +114,7 @@ void nn_fsm_raiseto (struct nn_fsm *self, struct nn_fsm *dst,
 
 /*  This function is very lowlevel action feeding
     Used in worker threads and timers, shouldn't be used by others
-    use nn_fsm_action/nn_fsm_raise/nn_fsm_raiseto instread*/
+    use nn_fsm_action/nn_fsm_raise/nn_fsm_raiseto instead*/
 void nn_fsm_feed (struct nn_fsm *self, int src, int type, void *srcptr);
 
 #endif

--- a/src/aio/usock_posix.inc
+++ b/src/aio/usock_posix.inc
@@ -79,7 +79,7 @@ static void nn_usock_shutdown (struct nn_fsm *self, int src, int type,
 
 void nn_usock_init (struct nn_usock *self, int src, struct nn_fsm *owner)
 {
-    /*  Initalise the state machine. */
+    /*  Initialise the state machine. */
     nn_fsm_init (&self->fsm, nn_usock_handler, nn_usock_shutdown,
         src, self, owner);
     self->state = NN_USOCK_STATE_IDLE;
@@ -112,7 +112,7 @@ void nn_usock_init (struct nn_usock *self, int src, struct nn_fsm *owner)
     nn_worker_task_init (&self->task_recv, NN_USOCK_SRC_TASK_RECV, &self->fsm);
     nn_worker_task_init (&self->task_stop, NN_USOCK_SRC_TASK_STOP, &self->fsm);
 
-    /*  Intialise events raised by usock. */
+    /*  Initialise events raised by usock. */
     nn_fsm_event_init (&self->event_established);
     nn_fsm_event_init (&self->event_sent);
     nn_fsm_event_init (&self->event_received);

--- a/src/aio/usock_win.inc
+++ b/src/aio/usock_win.inc
@@ -82,7 +82,7 @@ void nn_usock_init (struct nn_usock *self, int src, struct nn_fsm *owner)
     self->type = -1;
     self->protocol = -1;
 
-    /*  Intialise events raised by usock. */
+    /*  Initialise events raised by usock. */
     nn_fsm_event_init (&self->event_established);
     nn_fsm_event_init (&self->event_sent);
     nn_fsm_event_init (&self->event_received);
@@ -403,7 +403,7 @@ void nn_usock_send (struct nn_usock *self, const struct nn_iovec *iov,
     memset (&self->out.olpd, 0, sizeof (self->out.olpd));
     if (self->domain == AF_UNIX)
     {
-        /* TODO: Do not copy the buffer, find an efficent way to Write
+        /* TODO: Do not copy the buffer, find an efficient way to Write
            multiple buffers that doesn't affect the state machine. */
 
         /*  Ensure the total buffer size does not exceed size limitation

--- a/src/core/global.c
+++ b/src/core/global.c
@@ -59,7 +59,7 @@
 #include <unistd.h>
 #endif
 
-/*  Max number of concurrent SP sockets. Configureable at build time */
+/*  Max number of concurrent SP sockets. Configurable at build time */
 #ifndef NN_MAX_SOCKETS
 #define NN_MAX_SOCKETS 512
 #endif

--- a/src/core/sock.c
+++ b/src/core/sock.c
@@ -176,7 +176,7 @@ void nn_sock_stopped (struct nn_sock *self)
     nn_ctx_raise (self->fsm.ctx, &self->fsm.stopped);
 }
 
-/*  Stop the socket.  This will prevent new calls from aquiring a
+/*  Stop the socket.  This will prevent new calls from acquiring a
     hold on the socket, cause endpoints to shut down, and wake any
     threads waiting to recv or send data. */
 void nn_sock_stop (struct nn_sock *self)
@@ -534,7 +534,7 @@ int nn_sock_rm_ep (struct nn_sock *self, int eid)
 
     nn_ctx_enter (&self->ctx);
 
-    /*  Find the specified enpoint. */
+    /*  Find the specified endpoint. */
     ep = NULL;
     for (it = nn_list_begin (&self->eps);
           it != nn_list_end (&self->eps);

--- a/src/core/sock.h
+++ b/src/core/sock.h
@@ -112,7 +112,7 @@ struct nn_sock
         uint64_t messages_received;
         /*  Bytes sent (sum length of data in messages sent)  */
         uint64_t bytes_sent;
-        /*  Bytes recevied (sum length of data in messages received)  */
+        /*  Bytes received (sum length of data in messages received)  */
         uint64_t bytes_received;
 
         /*****  Level-style values *****/

--- a/src/protocols/bus/xbus.c
+++ b/src/protocols/bus/xbus.c
@@ -37,7 +37,7 @@
 
 /*  To make the algorithm super efficient we directly cast pipe pointers to
     pipe IDs (rather than maintaining a hash table). For this to work, it is
-    neccessary for the pointer to fit in 64-bit ID. */
+    necessary for the pointer to fit in 64-bit ID. */
 CT_ASSERT (sizeof (uint64_t) >= sizeof (struct nn_pipe*));
 
 /*  Implementation of nn_sockbase's virtual functions. */

--- a/src/protocols/reqrep/req.c
+++ b/src/protocols/reqrep/req.c
@@ -262,7 +262,7 @@ int nn_req_crecv (struct nn_sockbase *self, struct nn_msg *msg)
     if (nn_slow (!nn_req_inprogress (req)))
         return -EFSM;
 
-    /*  If reply was not yet recieved, wait further. */
+    /*  If reply was not yet received, wait further. */
     if (nn_slow (req->state != NN_REQ_STATE_DONE))
         return -EAGAIN;
 

--- a/src/protocols/utils/fq.c
+++ b/src/protocols/utils/fq.c
@@ -63,12 +63,12 @@ int nn_fq_recv (struct nn_fq *self, struct nn_msg *msg, struct nn_pipe **pipe)
     int rc;
     struct nn_pipe *p;
 
-    /*  Pipe is NULL only when there are no avialable pipes. */
+    /*  Pipe is NULL only when there are no available pipes. */
     p = nn_priolist_getpipe (&self->priolist);
     if (nn_slow (!p))
         return -EAGAIN;
 
-    /*  Receive the messsage. */
+    /*  Receive the message. */
     rc = nn_pipe_recv (p, msg);
     errnum_assert (rc >= 0, -rc);
 

--- a/src/protocols/utils/lb.c
+++ b/src/protocols/utils/lb.c
@@ -68,12 +68,12 @@ int nn_lb_send (struct nn_lb *self, struct nn_msg *msg, struct nn_pipe **to)
     int rc;
     struct nn_pipe *pipe;
 
-    /*  Pipe is NULL only when there are no avialable pipes. */
+    /*  Pipe is NULL only when there are no available pipes. */
     pipe = nn_priolist_getpipe (&self->priolist);
     if (nn_slow (!pipe))
         return -EAGAIN;
 
-    /*  Send the messsage. */
+    /*  Send the message. */
     rc = nn_pipe_send (pipe, msg);
     errnum_assert (rc >= 0, -rc);
 

--- a/src/transports/ipc/bipc.c
+++ b/src/transports/ipc/bipc.c
@@ -295,7 +295,7 @@ static int nn_bipc_listen (struct nn_bipc *self)
 
     /*  Delete the IPC file left over by eventual previous runs of
         the application. We'll check whether the file is still in use by
-        connecting to the endpoint. On Windows plaform, NamedPipe is used
+        connecting to the endpoint. On Windows platform, NamedPipe is used
         which does not have an underlying file. */
 #if defined NN_HAVE_UNIX_SOCKETS
     fd = socket (AF_UNIX, SOCK_STREAM, 0);

--- a/src/transports/tcp/ctcp.c
+++ b/src/transports/tcp/ctcp.c
@@ -131,7 +131,7 @@ int nn_ctcp_create (struct nn_ep *ep)
     self = nn_alloc (sizeof (struct nn_ctcp), "ctcp");
     alloc_assert (self);
 
-    /*  Initalise the endpoint. */
+    /*  Initialise the endpoint. */
     self->ep = ep;
     nn_ep_tran_setup (ep, &nn_ctcp_ep_ops, self);
 

--- a/src/transports/utils/backoff.h
+++ b/src/transports/utils/backoff.h
@@ -25,7 +25,7 @@
 
 #include "../../aio/timer.h"
 
-/*  Timer with exponential backoff. Actual wating time is (2^n-1)*minivl,
+/*  Timer with exponential backoff. Actual waiting time is (2^n-1)*minivl,
     meaning that first wait is 0 ms long, second one is minivl ms long etc. */
 
 #define NN_BACKOFF_TIMEOUT NN_TIMER_TIMEOUT

--- a/src/transports/utils/dns.c
+++ b/src/transports/utils/dns.c
@@ -71,7 +71,7 @@ int nn_dns_check_hostname (const char *name, size_t namelen)
             --namelen;
             ++labelsz;
 
-            /*  Labels longer than 63 charcters are not permitted. */
+            /*  Labels longer than 63 characters are not permitted. */
             if (labelsz > 63)
                 return -EINVAL;
 

--- a/src/transports/ws/cws.c
+++ b/src/transports/ws/cws.c
@@ -152,7 +152,7 @@ int nn_cws_create (struct nn_ep *ep)
     self->ep = ep;
     self->peer_gone = 0;
 
-    /*  Initalise the endpoint. */
+    /*  Initialise the endpoint. */
     nn_ep_tran_setup (ep, &nn_cws_ep_ops, self);
 
     /*  Check whether IPv6 is to be used. */

--- a/src/transports/ws/ws_handshake.c
+++ b/src/transports/ws/ws_handshake.c
@@ -190,7 +190,7 @@ void nn_ws_handshake_start (struct nn_ws_handshake *self,
     struct nn_usock *usock, struct nn_pipebase *pipebase,
     int mode, const char *resource, const char *host)
 {
-    /*  It's expected this resource has been allocated during intial connect. */
+    /*  It's expected this resource has been allocated during initial connect. */
     if (mode == NN_WS_CLIENT)
         nn_assert (strlen (resource) >= 1);
 
@@ -326,7 +326,7 @@ static int nn_ws_match_value (const char* termseq, const char **subj,
     if (len)
         *len = 0;
 
-    /*  Find first occurence of termination sequence. */
+    /*  Find first occurrence of termination sequence. */
     end = strstr (start, termseq);
 
     /*  Was a termination sequence found? */

--- a/src/utils/efd.c
+++ b/src/utils/efd.c
@@ -84,7 +84,7 @@ int nn_efd_wait (struct nn_efd *self, int timeout)
         rc = nn_err_wsa_to_posix (WSAGetLastError ());
         errno = rc;
 
-        /*  Treat these as a non-fatal errors, typically occuring when the
+        /*  Treat these as a non-fatal errors, typically occurring when the
             socket is being closed from a separate thread during a blocking
             I/O operation. */
         if (rc == EINTR || rc == ENOTSOCK) {

--- a/src/utils/efd.h
+++ b/src/utils/efd.h
@@ -63,7 +63,7 @@ void nn_efd_signal (struct nn_efd *self);
 void nn_efd_unsignal (struct nn_efd *self);
 
 /*  Wait till efd object becomes signaled or when timeout (in milliseconds,
-    nagative value meaning 'infinite') expires. In the former case 0 is
+    negative value meaning 'infinite') expires. In the former case 0 is
     returened. In the latter, -ETIMEDOUT. */
 int nn_efd_wait (struct nn_efd *self, int timeout);
 

--- a/src/utils/efd_win.inc
+++ b/src/utils/efd_win.inc
@@ -73,7 +73,7 @@ int nn_efd_init (struct nn_efd *self)
     if (rc == SOCKET_ERROR)
         goto wsafail;
 
-    /*  Start listening for the incomming connections. In normal case we are
+    /*  Start listening for the incoming connections. In normal case we are
         going to accept just a single connection, so backlog buffer of size
         1 is sufficient. */
     rc = listen (listener, 1);

--- a/src/utils/hash.h
+++ b/src/utils/hash.h
@@ -57,7 +57,7 @@ void nn_hash_insert (struct nn_hash *self, uint32_t key,
 void nn_hash_erase (struct nn_hash *self, struct nn_hash_item *item);
 
 /*  Gets an item in the hash based on the key. Returns NULL if there's no
-    corresponing item in the hash table. */
+    corresponding item in the hash table. */
 struct nn_hash_item *nn_hash_get (struct nn_hash *self, uint32_t key);
 
 /*  Initialise a hash item. At this point it is not a part of any hash table. */

--- a/src/utils/list.h
+++ b/src/utils/list.h
@@ -63,7 +63,7 @@ struct nn_list_item *nn_list_prev (struct nn_list *self,
 struct nn_list_item *nn_list_next (struct nn_list *self,
     struct nn_list_item *it);
 
-/*  Adds the item to the list before the item pointed to by 'it'. Priot to
+/*  Adds the item to the list before the item pointed to by 'it'. Prior to
     insertion item should not be part of any list. */
 void nn_list_insert (struct nn_list *self, struct nn_list_item *item,
     struct nn_list_item *it);

--- a/tests/device.c
+++ b/tests/device.c
@@ -43,7 +43,7 @@ void device1 (NN_UNUSED void *arg)
     int deva;
     int devb;
 
-    /*  Intialise the device sockets. */
+    /*  Initialise the device sockets. */
     deva = test_socket (AF_SP_RAW, NN_PAIR);
     test_bind (deva, SOCKET_ADDRESS_A);
     devb = test_socket (AF_SP_RAW, NN_PAIR);
@@ -64,7 +64,7 @@ void device2 (NN_UNUSED void *arg)
     int devc;
     int devd;
 
-    /*  Intialise the device sockets. */
+    /*  Initialise the device sockets. */
     devc = test_socket (AF_SP_RAW, NN_PULL);
     test_bind (devc, SOCKET_ADDRESS_C);
     devd = test_socket (AF_SP_RAW, NN_PUSH);
@@ -84,7 +84,7 @@ void device3 (NN_UNUSED void *arg)
     int rc;
     int deve;
 
-    /*  Intialise the device socket. */
+    /*  Initialise the device socket. */
     deve = test_socket (AF_SP_RAW, NN_BUS);
     test_bind (deve, SOCKET_ADDRESS_E);
 

--- a/tests/device4.c
+++ b/tests/device4.c
@@ -39,7 +39,7 @@ void device4 (NN_UNUSED void *arg)
     int devf;
     int devg;
 
-    /*  Intialise the device sockets. */
+    /*  Initialise the device sockets. */
     devf = test_socket (AF_SP_RAW, NN_REP);
     test_bind (devf, socket_address_f);
     devg = test_socket (AF_SP_RAW, NN_REQ);

--- a/tests/device5.c
+++ b/tests/device5.c
@@ -39,7 +39,7 @@ void device5 (NN_UNUSED void *arg)
     int dev0;
     int dev1;
 
-    /*  Intialise the device sockets. */
+    /*  Initialise the device sockets. */
     dev0 = test_socket (AF_SP_RAW, NN_REP);
     test_bind (dev0, socket_address_h);
     dev1 = test_socket (AF_SP_RAW, NN_REQ);

--- a/tests/device6.c
+++ b/tests/device6.c
@@ -39,7 +39,7 @@ void device5 (NN_UNUSED void *arg)
     int dev0;
     int dev1;
 
-    /*  Intialise the device sockets. */
+    /*  Initialise the device sockets. */
     dev0 = test_socket (AF_SP_RAW, NN_RESPONDENT);
     test_bind (dev0, socket_address_h);
     dev1 = test_socket (AF_SP_RAW, NN_SURVEYOR);

--- a/tests/device7.c
+++ b/tests/device7.c
@@ -42,7 +42,7 @@ void device5 (NN_UNUSED void *arg)
     int dev0;
     int dev1;
 
-    /*  Intialise the device sockets. */
+    /*  Initialise the device sockets. */
     dev0 = test_socket (AF_SP_RAW, NN_REP);
     test_bind (dev0, socket_address_h);
     dev1 = test_socket (AF_SP_RAW, NN_REQ);

--- a/tests/reqrep.c
+++ b/tests/reqrep.c
@@ -108,7 +108,7 @@ int main ()
     test_close (rep1);
 
     /*  Check sending a request when the peer is not available. (It should
-        be sent immediatelly when the peer comes online rather than relying
+        be sent immediately when the peer comes online rather than relying
         on the resend algorithm. */
     req1 = test_socket (AF_SP, NN_REQ);
     test_connect (req1, SOCKET_ADDRESS);
@@ -126,7 +126,7 @@ int main ()
     test_close (rep1);
 
     /*  Check removing socket request sent to (It should
-        be sent immediatelly to other peer rather than relying
+        be sent immediately to other peer rather than relying
         on the resend algorithm). */
     req1 = test_socket (AF_SP, NN_REQ);
     test_bind (req1, SOCKET_ADDRESS);

--- a/tests/reqttl.c
+++ b/tests/reqttl.c
@@ -64,7 +64,7 @@ int main (int argc, const char *argv[])
     test_addr_from(socket_address_a, "tcp", "127.0.0.1", port);
     test_addr_from(socket_address_b, "tcp", "127.0.0.1", port + 1);
 
-    /*  Intialise the device sockets. */
+    /*  Initialise the device sockets. */
     dev0 = test_socket (AF_SP_RAW, NN_REP);
     dev1 = test_socket (AF_SP_RAW, NN_REQ);
 

--- a/tests/surveyttl.c
+++ b/tests/surveyttl.c
@@ -64,7 +64,7 @@ int main (int argc, const char *argv[])
     test_addr_from(socket_address_a, "tcp", "127.0.0.1", port);
     test_addr_from(socket_address_b, "tcp", "127.0.0.1", port + 1);
 
-    /*  Intialise the device sockets. */
+    /*  Initialise the device sockets. */
     dev0 = test_socket (AF_SP_RAW, NN_RESPONDENT);
     dev1 = test_socket (AF_SP_RAW, NN_SURVEYOR);
 


### PR DESCRIPTION
The goal of this PR is to fix the spelling errors of words found by the codespell tool.   The codespell tool can be found at https://github.com/codespell-project/codespell .

And this PR solely consists of correcting spelling errors in code comments,  or several .txt/.xml files  under ` rfc` directory, without involving any functional changes.
