### PR TITLE
aio: fix build on Windows

### DIFF
--- a/src/aio/usock_win.h
+++ b/src/aio/usock_win.h
@@ -24,6 +24,7 @@
 #include "worker.h"
 
 #include "../utils/win.h"
+#include "worker_win.h"
 
 struct nn_usock {
 

--- a/src/aio/usock_win.inc
+++ b/src/aio/usock_win.inc
@@ -447,9 +447,8 @@ void nn_usock_send (struct nn_usock *self, const struct nn_iovec *iov,
     nn_fsm_action (&self->fsm, NN_USOCK_ACTION_ERROR);
 }
 
-void nn_usock_recv_start_wsock (void *arg)
+void nn_usock_recv_start_wsock (struct nn_usock *self)
 {
-    struct nn_usock *self = arg;
     WSABUF wbuf;
     DWORD flags;
     DWORD error;
@@ -478,9 +477,8 @@ void nn_usock_recv_start_wsock (void *arg)
     }
 }
 
-void nn_usock_recv_start_pipe (void *arg)
+void nn_usock_recv_start_pipe (struct nn_usock *self)
 {
-    struct nn_usock *self = arg;
     void *buf = self->in.buf;
     DWORD len = (DWORD) self->in.resid;
     DWORD error;

--- a/src/aio/worker_win.h
+++ b/src/aio/worker_win.h
@@ -22,6 +22,9 @@
     IN THE SOFTWARE.
 */
 
+#ifndef NN_WORKER_WIN_INCLUDED
+#define NN_WORKER_WIN_INCLUDED
+
 #include "fsm.h"
 #include "timerset.h"
 
@@ -35,6 +38,8 @@ struct nn_worker_task {
 
 #define NN_WORKER_OP_DONE 1
 #define NN_WORKER_OP_ERROR 2
+
+struct nn_usock;
 
 struct nn_worker_op {
     int src;
@@ -69,3 +74,5 @@ struct nn_worker {
 };
 
 HANDLE nn_worker_getcp (struct nn_worker *self);
+
+#endif


### PR DESCRIPTION
```
nanomsg/src/aio/usock_win.inc:523:24: error: assignment to 'void (*)(struct nn_usock *)' from incompatible pointer type 'void (*)(void *)' [-Wincompatible-pointer-types]
  523 |         self->in.start = nn_usock_recv_start_pipe;
      |                        ^
nanomsg/src/aio/usock_win.inc:526:24: error: assignment to 'void (*)(struct nn_usock *)' from incompatible pointer type 'void (*)(void *)' [-Wincompatible-pointer-types]
  526 |         self->in.start = nn_usock_recv_start_wsock;
      |                   
```