### PR TITLE
Fixed an error that caused a seg fault when there were not enough bind ports

### DIFF
--- a/src/transports/tcp/ctcp.c
+++ b/src/transports/tcp/ctcp.c
@@ -454,6 +454,15 @@ static void nn_ctcp_handler (struct nn_fsm *self, int src, int type,
                 nn_fsm_bad_action (ctcp->state, src, type);
             }
 
+        case NN_CTCP_SRC_USOCK:
+            /*  Ignore late-arriving usock events while waiting to reconnect. */
+            switch (type) {
+            case NN_USOCK_SHUTDOWN:
+                return;
+            default:
+                return;  /* Ignore other events */
+            }
+
         default:
             nn_fsm_bad_source (ctcp->state, src, type);
         }


### PR DESCRIPTION
I'm using NANOMSG on an huge network system.
However, NANOMSG often causes unintended seg faults.
Upon investigating the cause, I discovered it was due to a lack of ephemeral ports.
I suggest addressing this with this PR.

Reproducing code:
pub
```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <nanomsg/nn.h>
#include <nanomsg/pubsub.h>

int main(int argc, char **argv) {
    int sock;
    int rv;
    char *url = "tcp://*:5555";
    char *message = "Hello, World!";

    if (argc > 1) {
        url = argv[1];
    }

    if (argc > 2) {
        message = argv[2];
    }

    if ((sock = nn_socket(AF_SP, NN_PUB)) < 0) {
        fprintf(stderr, "nn_socket: %s\n", nn_strerror(nn_errno()));
        exit(1);
    }

    if ((rv = nn_bind(sock, url)) < 0) {
        fprintf(stderr, "nn_bind: %s\n", nn_strerror(nn_errno()));
        nn_close(sock);
        exit(1);
    }

    printf("Publisher started, binding to %s\n", url);
    printf("Publishing message: %s\n", message);
    printf("Press Ctrl+C to stop\n\n");

    while (1) {
        int bytes;
        if ((bytes = nn_send(sock, message, strlen(message), 0)) < 0) {
            fprintf(stderr, "nn_send: %s\n", nn_strerror(nn_errno()));
            break;
        }
        printf("Published: %s\n", message);
        sleep(1);
    }

    nn_close(sock);
    return 0;
}
```
sub
```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <nanomsg/nn.h>
#include <nanomsg/pubsub.h>

int main(int argc, char **argv) {
    int sock;
    int rv;
    char *url = "tcp://*:5555";
    char *message = "Hello, World!";

    if (argc > 1) {
        url = argv[1];
    }

    if (argc > 2) {
        message = argv[2];
    }

    if ((sock = nn_socket(AF_SP, NN_PUB)) < 0) {
        fprintf(stderr, "nn_socket: %s\n", nn_strerror(nn_errno()));
        exit(1);
    }

    if ((rv = nn_bind(sock, url)) < 0) {
        fprintf(stderr, "nn_bind: %s\n", nn_strerror(nn_errno()));
        nn_close(sock);
        exit(1);
    }

    printf("Publisher started, binding to %s\n", url);
    printf("Publishing message: %s\n", message);
    printf("Press Ctrl+C to stop\n\n");

    while (1) {
        int bytes;
        if ((bytes = nn_send(sock, message, strlen(message), 0)) < 0) {
            fprintf(stderr, "nn_send: %s\n", nn_strerror(nn_errno()));
            break;
        }
        printf("Published: %s\n", message);
        sleep(1);
    }

    nn_close(sock);
    return 0;
}
```

Here's how to reproduce it:
```bash
sudo sysctl -w net.ipv4.ip_local_port_range="10000 10004"
make
./pub &
./sub
```

Result:
```bash
...
[Subscriber #7] Started, connected to tcp://localhost:5555
[Subscriber #7] Subscribed to all messages
[Subscriber #7] Waiting for messages...

/usr/local/lib/libnanomsg.so.6(+0x38e90)[0x77a416a63e90]
/usr/local/lib/libnanomsg.so.6(+0x38e90)[0x77a416a63e90]
[Subscriber #6] Started, connected to tcp://localhost:5555
[Subscriber #6] Subscribed to all messages
[Subscriber #6] Waiting for messages...

/usr/local/lib/libnanomsg.so.6(+0x38e90)[0x77a416a63e90]
/usr/local/lib/libnanomsg.so.6(nn_fsm_feed+0x4a)[0x77a416a42fcb]
/usr/local/lib/libnanomsg.so.6(nn_fsm_event_process+0x6b)[0x77a416a42f7e]
/usr/local/lib/libnanomsg.so.6(nn_ctx_leave+0x60)[0x77a416a42d05]
/usr/local/lib/libnanomsg.so.6(+0x2c43c)[0x77a416a5743c]
/lib/x86_64-linux-gnu/libc.so.6(+0x1525fa)[0x77a4167525fa]
/lib/x86_64-linux-gnu/libc.so.6(+0x94ac3)[0x77a416694ac3]
/usr/local/lib/libnanomsg.so.6(nn_fsm_feed+0x4a)[0x77a416a42fcb]
/usr/local/lib/libnanomsg.so.6(+0x38e90)[0x77a416a63e90]
/usr/local/lib/libnanomsg.so.6(nn_fsm_event_process+0x6b)[0x77a416a42f7e]
/usr/local/lib/libnanomsg.so.6(nn_fsm_feed+0x4a)[0x77a416a42fcb]
/lib/x86_64-linux-gnu/libc.so.6(+0x1268c0)[0x77a4167268c0]
/usr/local/lib/libnanomsg.so.6(+0x38e90)[0x77a416a63e90]
[Subscriber #3] Started, connected to tcp://localhost:5555
[Subscriber #3] Subscribed to all messages
Unexpected source: state=8 source=1 action=7 (nanomsg/src/transports/tcp/ctcp.c:458)
[Subscriber #3] Waiting for messages...

/usr/local/lib/libnanomsg.so.6(nn_fsm_feed+0x4a)[0x77a416a42fcb]
/usr/local/lib/libnanomsg.so.6(nn_ctx_leave+0x60)[0x77a416a42d05]
/usr/local/lib/libnanomsg.so.6(nn_fsm_event_process+0x6b)[0x77a416a42f7e]
/usr/local/lib/libnanomsg.so.6(nn_fsm_event_process+0x6b)[0x77a416a42f7e]
/usr/local/lib/libnanomsg.so.6(+0x2c43c)[0x77a416a5743c]
/lib/x86_64-linux-gnu/libc.so.6(+0x1525fa)[0x77a4167525fa]
/lib/x86_64-linux-gnu/libc.so.6(+0x94ac3)[0x77a416694ac3]
/lib/x86_64-linux-gnu/libc.so.6(+0x1268c0)[0x77a4167268c0]
Unexpected source: state=8 source=1 action=7 (nanomsg/src/transports/tcp/ctcp.c:458)
Published: Hello, World!
Aborted (core dumped)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TCP reconnection handling to properly ignore stale socket events during reconnection wait, preventing connection-related issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->